### PR TITLE
revert: update zb_endpoint_descriptors on every init

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -891,11 +891,11 @@ class ZigBeeDevice extends Homey.Device {
     // Important: this is needed when migrating from zigbee-shepherd to node-zigbee. A device
     // paired with the shepherd stack does not have the `zb_endpoint_descriptors` setting, which
     // is required for the node-zigbee stack. If it is not available retrieve it from the
-    // manifest once and save it.
-    if (!this.getSetting('zb_endpoint_descriptors')) {
-      const { manifest } = this.driver;
-      await this.setSettings({ zb_endpoint_descriptors: manifest.zigbee.endpoints });
-    }
+    // manifest once and save it. TODO: re-enable if statement below once we are past experimental
+    // if (!this.getSetting('zb_endpoint_descriptors')) {
+    const { manifest } = this.driver;
+    await this.setSettings({ zb_endpoint_descriptors: manifest.zigbee.endpoints });
+    // }
 
     // Get ZigBeeNode instance from ManagerZigBee
     this.homey.zigbee.getNode(this)


### PR DESCRIPTION
Note: should be removed after we are past experimental phase, then it is better to only set the endpoint descriptors directly after pairing.