### PR TITLE
fix(zigbee-device): remove `setSettings` for endpoint descriptors from manifest

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -895,15 +895,6 @@ class ZigBeeDevice extends Homey.Device {
     // Bind __ with current language
     this.zigbeedriverI18n = __.bind(this, this.homey.i18n.getLanguage());
 
-    // Important: this is needed when migrating from zigbee-shepherd to node-zigbee. A device
-    // paired with the shepherd stack does not have the `zb_endpoint_descriptors` setting, which
-    // is required for the node-zigbee stack. If it is not available retrieve it from the
-    // manifest once and save it. TODO: re-enable if statement below once we are past experimental
-    // if (!this.getSetting('zb_endpoint_descriptors')) {
-    const { manifest } = this.driver;
-    await this.setSettings({ zb_endpoint_descriptors: manifest.zigbee.endpoints });
-    // }
-
     // Get ZigBeeNode instance from ManagerZigBee
     this.homey.zigbee.getNode(this)
       .then(async node => {


### PR DESCRIPTION
In the future this will be handled by the Homey Apps SDK.

Note: this should be merged only after the SDK is updated in Experimental (likely 5.0.0-rc.24).