### PR TITLE
feat: sub device

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 examples/*
 assets/*
+build

--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@
 module.exports.Util = require('./lib/util');
 
 module.exports.ZigBeeDevice = require('./lib/ZigBeeDevice.js');
+module.exports.ZigBeeDriver = require('./lib/ZigBeeDriver.js');
 module.exports.ZigBeeLightDevice = require('./lib/ZigBeeLightDevice.js');

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -4,6 +4,8 @@
 const Homey = require('homey');
 const { ZCLNode } = require('zigbee-clusters');
 
+const ZigBeeDriver = require('./ZigBeeDriver');
+
 const {
   __,
   assertClusterSpecification,
@@ -895,6 +897,8 @@ class ZigBeeDevice extends Homey.Device {
     // Bind __ with current language
     this.zigbeedriverI18n = __.bind(this, this.homey.i18n.getLanguage());
 
+    const { token } = this.getData();
+
     // Important: this is needed when migrating from zigbee-shepherd to node-zigbee. A device
     // paired with the shepherd stack does not have the `zb_endpoint_descriptors` setting, which
     // is required for the node-zigbee stack. If it is not available retrieve it from the
@@ -903,6 +907,13 @@ class ZigBeeDevice extends Homey.Device {
     const { manifest } = this.driver;
     await this.setSettings({ zb_endpoint_descriptors: manifest.zigbee.endpoints });
     // }
+
+    // Throw error if this device is a Zigbee endpoint device but its driver does not extend
+    // ZigBeeDriver.
+    if (this.isEndpointDevice() && !(this.driver instanceof ZigBeeDriver)) {
+      this.error(`Error: Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee endpoint devices`);
+      throw new Error(`Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee endpoint devices`);
+    }
 
     // Get ZigBeeNode instance from ManagerZigBee
     this.homey.zigbee.getNode(this)
@@ -918,10 +929,25 @@ class ZigBeeDevice extends Homey.Device {
           await this.setEnergy(energyObject);
         }
 
-        // Create ZCLNode instance
-        this.zclNode = new ZCLNode(this.node);
+        // If this is a Zigbee endpoint device
+        if (this.isEndpointDevice()) {
+          // And a ZCLNode instance is already available on the driver
+          if (this.driver._zclNodes.has(token)) {
+            // Re-use ZCLNode instance, this is needed for Zigbee endpoint devices which share a
+            // single ZCLNode instance
+            this.zclNode = this.driver._zclNodes.get(token);
+          }
+        }
 
-        this.log(`ZigBeeDevice has been initialized (first init: ${this.isFirstInit()})`);
+        // If no ZCLNode could be re-used, create a new one
+        if (!this.zclNode) this.zclNode = new ZCLNode(this.node);
+
+        // If possible, register it with the driver for future re-use
+        if (this.driver._zclNodes instanceof Map && !this.driver._zclNodes.has(token)) {
+          this.driver._zclNodes.set(token, this.zclNode);
+        }
+
+        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isEndpointDevice: this.isEndpointDevice() });
 
         // Mark device as available
         await this.setAvailable();
@@ -941,6 +967,16 @@ class ZigBeeDevice extends Homey.Device {
         this.setUnavailable(this.zigbeedriverI18n('error.node_initialization'))
           .catch(unavailableErr => this.error('could not set device unavailable', unavailableErr));
       });
+  }
+
+  /**
+   * Returns the endpoint id if this device is a Zigbee endpoint device (TODO: better name?)
+   * else null.
+   * @returns {EndpointId|null}
+   */
+  isEndpointDevice() {
+    if (typeof this.getData().endpointId !== 'number') return null;
+    return this.getData().endpointId;
   }
 
   /**

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -946,7 +946,7 @@ class ZigBeeDevice extends Homey.Device {
           this.driver._zclNodes.set(token, this.zclNode);
         }
 
-        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isSubDevice: this.isSubDevice() });
+        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isSubDevice: this.isSubDevice() && this.getData().endpointId });
 
         // Mark device as available
         await this.setAvailable();
@@ -970,11 +970,10 @@ class ZigBeeDevice extends Homey.Device {
 
   /**
    * Returns the endpoint id if this device is a Zigbee sub device else null.
-   * @returns {EndpointId|null}
+   * @returns {boolean}
    */
   isSubDevice() {
-    if (typeof this.getData().endpointId !== 'number') return null;
-    return this.getData().endpointId;
+    return typeof this.getData().endpointId === 'number';
   }
 
   /**

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -946,7 +946,7 @@ class ZigBeeDevice extends Homey.Device {
           this.driver._zclNodes.set(token, this.zclNode);
         }
 
-        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isSubDevice: this.isSubDevice() && this.getData().endpointId });
+        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isSubDevice: this.isSubDevice() });
 
         // Mark device as available
         await this.setAvailable();
@@ -969,11 +969,11 @@ class ZigBeeDevice extends Homey.Device {
   }
 
   /**
-   * Returns the endpoint id if this device is a Zigbee sub device else null.
+   * Returns true if this device is a Zigbee sub device else null.
    * @returns {boolean}
    */
   isSubDevice() {
-    return typeof this.getData().endpointId === 'number';
+    return typeof this.getData().subDeviceId === 'string';
   }
 
   /**

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -908,11 +908,10 @@ class ZigBeeDevice extends Homey.Device {
     await this.setSettings({ zb_endpoint_descriptors: manifest.zigbee.endpoints });
     // }
 
-    // Throw error if this device is a Zigbee endpoint device but its driver does not extend
-    // ZigBeeDriver.
-    if (this.isEndpointDevice() && !(this.driver instanceof ZigBeeDriver)) {
-      this.error(`Error: Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee endpoint devices`);
-      throw new Error(`Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee endpoint devices`);
+    // Throw error if this device is a Zigbee sub device but its driver does not extend ZigBeeDriver
+    if (this.isSubDevice() && !(this.driver instanceof ZigBeeDriver)) {
+      this.error(`Error: Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee sub devices`);
+      throw new Error(`Driver ${this.driver.id} must extend ZigBeeDriver when using Zigbee sub devices`);
     }
 
     // Get ZigBeeNode instance from ManagerZigBee
@@ -929,11 +928,11 @@ class ZigBeeDevice extends Homey.Device {
           await this.setEnergy(energyObject);
         }
 
-        // If this is a Zigbee endpoint device
-        if (this.isEndpointDevice()) {
+        // If this is a Zigbee sub device
+        if (this.isSubDevice()) {
           // And a ZCLNode instance is already available on the driver
           if (this.driver._zclNodes.has(token)) {
-            // Re-use ZCLNode instance, this is needed for Zigbee endpoint devices which share a
+            // Re-use ZCLNode instance, this is needed for Zigbee sub devices which share a
             // single ZCLNode instance
             this.zclNode = this.driver._zclNodes.get(token);
           }
@@ -947,7 +946,7 @@ class ZigBeeDevice extends Homey.Device {
           this.driver._zclNodes.set(token, this.zclNode);
         }
 
-        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isEndpointDevice: this.isEndpointDevice() });
+        this.log('ZigBeeDevice has been initialize', { firstInit: this.isFirstInit(), isSubDevice: this.isSubDevice() });
 
         // Mark device as available
         await this.setAvailable();
@@ -970,11 +969,10 @@ class ZigBeeDevice extends Homey.Device {
   }
 
   /**
-   * Returns the endpoint id if this device is a Zigbee endpoint device (TODO: better name?)
-   * else null.
+   * Returns the endpoint id if this device is a Zigbee sub device else null.
    * @returns {EndpointId|null}
    */
-  isEndpointDevice() {
+  isSubDevice() {
     if (typeof this.getData().endpointId !== 'number') return null;
     return this.getData().endpointId;
   }

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -969,7 +969,7 @@ class ZigBeeDevice extends Homey.Device {
   }
 
   /**
-   * Returns true if this device is a Zigbee sub device else null.
+   * Returns true if this device is a Zigbee sub device.
    * @returns {boolean}
    */
   isSubDevice() {

--- a/lib/ZigBeeDriver.js
+++ b/lib/ZigBeeDriver.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Homey = require('homey');
+
+class ZigBeeDriver extends Homey.Driver {
+
+  /**
+   * @private
+   * @type {Map<Token, ZCLNode>}
+   */
+  _zclNodes = new Map();
+
+}
+
+module.exports = ZigBeeDriver;

--- a/lib/ZigBeeDriver.js
+++ b/lib/ZigBeeDriver.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line node/no-unpublished-require
 const Homey = require('homey');
 
 class ZigBeeDriver extends Homey.Driver {

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -319,6 +319,7 @@ function wrapAsyncWithRetry(
  * @deprecated since 1.5.0
  */
 function debugZigbeeClusters(...args) {
+  // eslint-disable-next-line no-console
   console.warn('DEPRECATED WARNING: please replace `debugZigbeeClusters` by `debug` from'
     + ' zigbee-clusters: https://athombv.github.io/node-zigbee-clusters/global.html#debug');
   return debug(...args);

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,9 +367,9 @@
       "dev": true
     },
     "athom-api": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/athom-api/-/athom-api-3.2.3.tgz",
-      "integrity": "sha512-2uBFOHz/96NzbISxLch75aNoH3XYjUJn5ev5qQkBCY2+XyyvWLwdT7d3FY9P2loR1tpn8lAMfefcT3NWkaUa1A==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/athom-api/-/athom-api-3.2.13.tgz",
+      "integrity": "sha512-2HDri+TdOyjr7lroMVfNGRoIzjMz5yUWmpbwjvIJoXgFMzJO1y6GC8kkyMneMtJvq1Oc1626WMgjHwPutBgbYA==",
       "dev": true
     },
     "atob": {
@@ -503,12 +503,6 @@
         "type-is": "~1.6.17"
       },
       "dependencies": {
-        "bytes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -518,59 +512,10 @@
             "ms": "2.0.0"
           }
         },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-          "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.1.0",
-            "http-errors": "1.7.2",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
           "dev": true
         }
       }
@@ -674,6 +619,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
     },
     "cache-base": {
@@ -927,9 +878,9 @@
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "component-emitter": {
@@ -1195,6 +1146,12 @@
           }
         }
       }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
@@ -1790,28 +1747,10 @@
             "ms": "2.0.0"
           }
         },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
           "dev": true
         }
       }
@@ -2329,9 +2268,9 @@
       "dev": true
     },
     "homey": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/homey/-/homey-2.3.1.tgz",
-      "integrity": "sha512-Pc8H04GhAu2JbUXpevqSWOODEN6GPBLBYLBA5EhUpSR+OnTPhsOpJARC3MNtkxwLKcErSUCP4ALbII1kZZjiiQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/homey/-/homey-2.6.1.tgz",
+      "integrity": "sha512-rx1k8cLrmnm4Y5ykQ/U6cZ4RU/dz46VJnR8v3oNSVe3yTCHiTRdztvYGB9TmQKgEGNunoz0enhoHpEVfREwz5w==",
       "dev": true,
       "requires": {
         "athom-api": "^3.1.1",
@@ -2343,7 +2282,7 @@
         "filesize": "^3.6.1",
         "fs-extra": "^5.0.0",
         "gitignore-parser": "0.0.2",
-        "homey-lib": "^2.4.9",
+        "homey-lib": "^2.4.12",
         "ignore-walk": "^3.0.3",
         "ini": "^1.3.5",
         "inquirer": "^5.1.0",
@@ -2646,14 +2585,14 @@
       }
     },
     "homey-lib": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/homey-lib/-/homey-lib-2.4.9.tgz",
-      "integrity": "sha512-O/M05tgi3JYOR9zn/B0WdTxeAUOpnMsYJv/oowyfCH9CMrkUsVQB2Me5UovfDkqonYty/xLtbd9HtlApjoR3xA==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/homey-lib/-/homey-lib-2.4.12.tgz",
+      "integrity": "sha512-FXagsW/WtnHhtGkc+EN0U0RbrkS82rLF1A4N3Up3cYh7sAk5619kIIh2Q7CEy0VubJegKI566n9nQlJbB3QTng==",
       "dev": true,
       "requires": {
         "ajv": "^6.1.1",
         "image-size": "^0.6.2",
-        "semver": "^5.5.0",
+        "semver": "^5.7.0",
         "tinycolor2": "^1.4.1"
       }
     },
@@ -2667,6 +2606,27 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
       "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -4623,6 +4583,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
+    },
     "ramda": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
@@ -4634,6 +4600,18 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -4968,35 +4946,10 @@
             }
           }
         },
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.4",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
           "dev": true
         }
       }
@@ -5155,6 +5108,12 @@
           }
         }
       }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "concurrently": "^5.1.0",
     "eslint": "^6.8.0",
     "eslint-config-athom": "^2.0.8",
+    "homey": "^2.6.1",
     "jsdoc": "^3.6.4",
+    "mocha": "^7.1.1",
     "npm-watch": "^0.6.0",
     "serve": "^11.3.1",
-    "homey": "^2.1.5",
-    "mocha": "^7.1.1",
     "zigbee-clusters": "^1.2.2"
   },
   "engines": {


### PR DESCRIPTION
This PR detects if a `ZigBeeDevice` instance is a sub device, in that case it will try to share a `ZCLNode` with its root/sibling devices. This means that all sub devices and the root device share one `ZCLNode` and have access to all endpoints. Not sure if that is desired, also not sure how to solve that potentially though.

This implementation does require the driver of the device to extend `ZigBeeDriver` in order to share the `ZCLNode`.