### PR TITLE
Fix debounced function argument passing

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -212,14 +212,14 @@ function debounce(fn, interval, immediate = false) {
       timeout = null;
 
       // Do not trigger immediately (trailing debounce)
-      if (!immediate) fn.apply(context, ...args);
+      if (!immediate) fn.apply(context, args);
     };
 
     // Trigger immediately (leading debounce)
     const callNow = immediate && !timeout;
     clearTimeout(timeout);
     timeout = setTimeout(later, interval);
-    if (callNow) fn.apply(context, ...args);
+    if (callNow) fn.apply(context, args);
   };
 }
 


### PR DESCRIPTION
I was wondering why my arguments where not forwarded to the debounced function, this PR solves it for this example:


```js
    this.debouncedMoveUpHandler = Util
      .debounce(payload => this.moveCommandParser(payload), 300, true);
    this.debouncedMoveDownHandler = Util
      .debounce(payload => this.moveCommandParser(payload), 300, true);

    zclNode.endpoints[1].bind(CLUSTER.LEVEL_CONTROL.NAME, new LevelControlBoundCluster({
      onMove: payload => {
        if (payload.moveMode === 'up') {
          this.debouncedMoveUpHandler(payload);
        } else if (payload.moveMode === 'down') {
          this.debouncedMoveDownHandler(payload);
        }
      },
    }));
```