### PR TITLE
fix: await level control set capability value

### DIFF
--- a/lib/system/capabilities/dim/levelControl.js
+++ b/lib/system/capabilities/dim/levelControl.js
@@ -15,12 +15,8 @@ module.exports = {
    * @param {object} opts
    * @returns {{transitionTime: number, level: number}}
    */
-  setParser(value, opts = {}) {
-    if (value === 0) {
-      this.setCapabilityValue('onoff', false);
-    } else if (this.getCapabilityValue('onoff') === false && value > 0) {
-      this.setCapabilityValue('onoff', true);
-    }
+  async setParser(value, opts = {}) {
+    await this.setCapabilityValue('onoff', value > 0);
 
     return {
       level: Math.round(value * MAX_DIM),


### PR DESCRIPTION
Awaits `setCapabilityValue()` in levelControl `setParser()`.
When I reviewed this last time I mistakenly assumed these where fine since their values are hard-coded. This is true in theory but when unexpected errors (such as network related errors) occur these might still cause unhandled promise rejections.
Not sure what the reason for the `getCapabilityValue()` was but it seems unnecessary?