### PR TITLE
Fix pressure measurement value parser

### DIFF
--- a/lib/system/capabilities/measure_pressure/pressureMeasurement.js
+++ b/lib/system/capabilities/measure_pressure/pressureMeasurement.js
@@ -12,8 +12,13 @@ module.exports = {
    * @returns {number}
    */
   reportParser(value) {
+    if (value === 0x8000) {
+      return null;
+    }
+
     // MeasuredValue represents the pressure in kPa as follows:
     // MeasuredValue = 10 x Pressure
-    return Math.round((value / 10) * 10) / 10;
+    // However, as 1 kPa == 10 mbar, it only needs to be rounded
+    return value;
   },
 };


### PR DESCRIPTION
The parser returned the value in kPa, while the capability expects mbar. By just returning the incoming value this is solved as 1kPa == 10mbar, negating the factor 10 in the specification for kPa (so yeah, they are actually using mbar). I've also added a check for the invalid value, so it returns null.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1835343/227976845-e80d472a-55e7-4d0a-88ca-2d22c9ea7128.png">
