### PR TITLE
Add support for attribute write with registerCapability method

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -233,6 +233,8 @@ class ZigBeeDevice extends Homey.Device {
    * command will be executed when the capability is set.
    * @property {SetParserFunction} [setParser] - Method that will be called before `set` is
    * called, to generate the parameters for the Cluster command execution.
+   * @property {boolean} [useAttributeWrite] - When set to true, the value of set will be used as
+   * attribute name to write the (parsed) capability value to.
    *
    * @property {string} [report] - Cluster attribute as specified in {@link Cluster.ATTRIBUTES}.
    * When a report is received for this attribute the respective `reportParser` will be called.
@@ -779,7 +781,7 @@ class ZigBeeDevice extends Homey.Device {
     assertCapabilityId(capabilityId, this.hasCapability.bind(this));
 
     const { setParser, endpoint } = this._getClusterCapabilityConfiguration(capabilityId, cluster);
-    let { set } = this._getClusterCapabilityConfiguration(capabilityId, cluster);
+    let { set, useAttributeWrite } = this._getClusterCapabilityConfiguration(capabilityId, cluster);
 
     assertZCLNode(this.zclNode, endpoint, cluster);
     if (typeof setParser !== 'function') throw new TypeError('set_parser_is_not_a_function');
@@ -791,6 +793,9 @@ class ZigBeeDevice extends Homey.Device {
     // `set` can be a function, in that case call the function to convert to a string value
     if (typeof set === 'function') set = set(value, opts);
 
+    // Type safety for attribute write option
+    useAttributeWrite = useAttributeWrite === true;
+
     // Call the `setParser` to generate the command properties which will be passed when
     // executing the cluster command
     const parsedPayload = await setParser.call(this, value, opts);
@@ -798,20 +803,22 @@ class ZigBeeDevice extends Homey.Device {
 
     // In the case that the parser returns `null` do not continue executing the command
     if (parsedPayload === null) {
-      this.debug(`WARNING: set ${capabilityId} → ${value} (command: ${set}, cluster: ${cluster.NAME}, endpoint: ${endpoint}) returned \`null\`, ignoring command set`);
+      this.debug(`WARNING: set ${capabilityId} → ${value} (${useAttributeWrite ? 'attribute' : 'command'}: ${set}, cluster: ${cluster.NAME}, endpoint: ${endpoint}) returned \`null\`, ignoring command set`);
       return null;
     }
 
-    this.debug(`set ${capabilityId} → ${value} (command: ${set}, cluster: ${cluster.NAME}, endpoint: ${endpoint}), parsed payload:`, parsedPayload);
+    this.debug(`set ${capabilityId} → ${value} (${useAttributeWrite ? 'attribute' : 'command'}: ${set}, cluster: ${cluster.NAME}, endpoint: ${endpoint}), parsed payload:`, parsedPayload);
 
     // Execute the cluster command with retry (1-time, directly)
-    return wrapAsyncWithRetry(
-      this.zclNode.endpoints[endpoint].clusters[cluster.NAME][set]
-        .bind(this.zclNode.endpoints[endpoint].clusters[cluster.NAME], parsedPayload),
-    ).catch(err => {
-      this.error(`Error: could not perform ${set} on cluster: ${cluster.NAME}, endpoint: ${endpoint} for capability ${capabilityId}`, err);
-      throw new Error(this.zigbeedriverI18n('error.command_failed'));
-    });
+    return wrapAsyncWithRetry(useAttributeWrite
+      ? this.zclNode.endpoints[endpoint].clusters[cluster.NAME].writeAttributes
+        .bind(this.zclNode.endpoints[endpoint].clusters[cluster.NAME], { [set]: parsedPayload })
+      : this.zclNode.endpoints[endpoint].clusters[cluster.NAME][set]
+        .bind(this.zclNode.endpoints[endpoint].clusters[cluster.NAME], parsedPayload))
+      .catch(err => {
+        this.error(`Error: could not perform ${set} on cluster: ${cluster.NAME}, endpoint: ${endpoint} for capability ${capabilityId}`, err);
+        throw new Error(this.zigbeedriverI18n('error.command_failed'));
+      });
   }
 
   /**


### PR DESCRIPTION
Currently, the registerCapability could only handle commands to update a capability value on a device. By introducing an optional useAttributeWrite property, developers can easily configure that their capability needs to be updated by writing to the property configured with the set parameter.