### PR TITLE
fix: sharing ZCL node between multiple ZigBeeDevice instances

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -916,14 +916,11 @@ class ZigBeeDevice extends Homey.Device {
           await this.setEnergy(energyObject);
         }
 
-        // If this is a Zigbee sub device
-        if (this.isSubDevice()) {
-          // And a ZCLNode instance is already available on the driver
-          if (this.driver._zclNodes.has(token)) {
-            // Re-use ZCLNode instance, this is needed for Zigbee sub devices which share a
-            // single ZCLNode instance
-            this.zclNode = this.driver._zclNodes.get(token);
-          }
+        // And a ZCLNode instance is already available on the driver
+        if (this.driver._zclNodes instanceof Map && this.driver._zclNodes.has(token)) {
+          // Re-use ZCLNode instance, this is needed for Zigbee sub devices which share a
+          // single ZCLNode instance
+          this.zclNode = this.driver._zclNodes.get(token);
         }
 
         // If no ZCLNode could be re-used, create a new one


### PR DESCRIPTION
The need to share a single ZCLNode instance between multiple ZigBeeDevice instances is due to the fact that a ZCLNode is stateful for a single node. This means it reacts to incoming frames. If there would be multiple ZCLNode instances reacting to the same incoming frames, weird behavior would occur. Therefore, Zigbee sub devices (similar to Z-Wave multichannel nodes) share a single ZCLNode instance. It appears there was a bug in the case that a Homey device consisted of 1 main device, and one or more sub devices. In that scenario, it would happen that the sub devices share a ZCLNode as expected (as they both pass the `isSubDevice()` check), but then the main device is initialized and does not pass the `isSubDevice()` check and therefore creates its own instance of ZCLNode, which overrides the `node.handleFrame` method of the ZCLNode instance from the sub devices. This results in the sub devices receiving no incoming frames any more.

This commits fixes that situation by removing the `isSubDevice()` check and just checking if the given token already has a ZCLNode instance available on the driver, in that case share it.