### PR TITLE
feat: Add function for Zigbee device liveness monitoring

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -1557,7 +1557,7 @@ class ZigBeeDevice extends Homey.Device {
       this.error('Interval or retry count is invalid.');
       return;
     }
-    if ((reportingCluster && !reportingAttributeName)npm
+    if ((reportingCluster && !reportingAttributeName)
       || (!reportingCluster && reportingAttributeName)) {
       this.error('reportingCluster, reportingAttributeName should provide both');
       return;

--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line node/no-unpublished-require
 const Homey = require('homey');
-const { ZCLNode } = require('zigbee-clusters');
+const { ZCLNode, CLUSTER } = require('zigbee-clusters');
 
 const ZigBeeDriver = require('./ZigBeeDriver');
 
@@ -17,6 +17,14 @@ const {
 
 const CAPABILITIES_DEBOUNCE = 500; // ms
 const CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY = 'configuredAttributeReporting';
+
+// Constants for offline monitoring
+const DEFAULT_ALWAYS_ON_DEVICE_CHECK_INTERVAL_SEC = 600;
+const DEFAULT_ALWAYS_ON_DEVICE_CHECK_COUNT = 2;
+const DEFAULT_SLEEPY_DEVICE_CHECK_COUNT = 4;
+const SLEEPY_DEVICE_INTERVAL_MARGIN_SEC = 30;
+const MIN_INTERVAL_SECONDS = 60;
+const ONLINE_CHECK_THROTTLE_MS = 10 * 1000; // ms
 
 /**
  * Every {@link ClusterCapabilityConfiguration} will be extended from this defaults object to
@@ -126,6 +134,9 @@ class ZigBeeDevice extends Homey.Device {
    */
   onEndDeviceAnnounce() {
     this.log('Received end device announce indication');
+    this.markDeviceOnline().catch(err => {
+      this.error('Error in markDeviceOnline:', err);
+    });
   }
 
   /**
@@ -659,10 +670,10 @@ class ZigBeeDevice extends Homey.Device {
               // Store configuration for later reference
               const currentValue = this.getStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY);
 
-              await this.setStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY, [{
-                ...(currentValue || {}),
-                ...configureAttributeReportingOptions,
-              }]);
+              await this.setStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY, [
+                ...(currentValue || []),
+                ...[configureAttributeReportingOptions],
+              ]);
 
               this.debug(`stored attribute reporting configuration (endpoint: ${endpointId}, cluster: ${clusterName})`, this.getStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY));
             })
@@ -894,6 +905,7 @@ class ZigBeeDevice extends Homey.Device {
     this._pollIntervals = {};
     this._clusterCapabilityConfigurations = new Map();
     this._flowTriggers = {};
+    this._isAttachOnlineListener = false;
 
     // Bind __ with current language
     this.zigbeedriverI18n = __.bind(this, this.homey.i18n.getLanguage());
@@ -1012,6 +1024,10 @@ class ZigBeeDevice extends Homey.Device {
             });
         });
     }
+
+    this.stopAlwaysOnDeviceOfflineMonitor();
+    this.stopSleepyDeviceOfflineMonitor();
+
     this.debug('deleted ZigBeeDevice instance');
   }
 
@@ -1353,6 +1369,271 @@ class ZigBeeDevice extends Homey.Device {
       // Store the new cluster capability configuration map
       this._clusterCapabilityConfigurations.set(capabilityId, clusterCapabilityConfigurationMap);
     }
+  }
+
+
+  /**
+   * Sets up a periodic timer to check if an always-on device is offline.
+   * Checks the device's online status by reading an attribute from the Basic cluster.
+   * If the read fails repeatedly, the device is marked as offline.
+   * @param {number} [intervalSeconds] - The interval in seconds between checks. 60 or greater.
+   * @param {number} [retryCount] - The number of consecutive failed reads before offline.
+   */
+  async startAlwaysOnDeviceOfflineMonitor(
+    intervalSeconds = DEFAULT_ALWAYS_ON_DEVICE_CHECK_INTERVAL_SEC,
+    retryCount = DEFAULT_ALWAYS_ON_DEVICE_CHECK_COUNT,
+  ) {
+    if (!this.node.receiveWhenIdle) {
+      this.log('may battery type device');
+    }
+    if (typeof intervalSeconds !== 'number' || intervalSeconds < MIN_INTERVAL_SECONDS
+      || typeof retryCount !== 'number' || retryCount <= 0) {
+      this.error('Interval or retry count is invalid.');
+      return;
+    }
+    if (this.driver.manifest.zigbee?.livenessOwner !== 'app') {
+      this.error('no liveness manifest ');
+      return;
+    }
+    const basicEndpoint = this.getClusterEndpoint(CLUSTER.BASIC);
+    if (typeof basicEndpoint !== 'number') {
+      this.error('get basic cluster endpoint fail');
+      return;
+    }
+    this._lastUpdateTime = 0;
+    await this._attachOnlineCheckListener();
+    this.stopAlwaysOnDeviceOfflineMonitor();
+
+    this.log('startAlwaysOnDeviceOfflineMonitor', intervalSeconds, retryCount);
+    const readAttributeName = 'modelId';
+    this.alwaysOnDeviceRetryCount = 0;
+    // Mark the device as offline if no signal is received within interval * count
+    this.alwaysOnDeviceOfflineTimer = this.homey.setInterval(async () => {
+      try {
+        // Read values from the mandatory Basic cluster
+        const readAttr = await this.zclNode.endpoints[basicEndpoint]
+          .clusters[CLUSTER.BASIC.NAME].readAttributes([readAttributeName]);
+
+        if (readAttr) {
+          await this._markAlwaysOnDeviceOnline();
+        } else {
+          this.alwaysOnDeviceRetryCount++;
+        }
+      } catch (err) {
+        this.alwaysOnDeviceRetryCount++;
+        this.error('Error reading attributes:', err);
+      }
+      if (this.alwaysOnDeviceRetryCount >= retryCount) {
+        this.alwaysOnDeviceRetryCount = 0;
+        if (this.getAvailable()) {
+          await this.setUnavailable();
+          this.log('Device is offline ', this.getName());
+        }
+      }
+    }, intervalSeconds * 1000);
+  }
+
+  /**
+   * Marks device as online.
+   */
+  async markDeviceOnline() {
+    const now = Date.now();
+    if (now - this._lastUpdateTime < ONLINE_CHECK_THROTTLE_MS) {
+      // Skip execution if the function is called too frequently
+      return;
+    }
+    this._lastUpdateTime = now;
+    await this._markAlwaysOnDeviceOnline();
+    await this._markSleepyDeviceOnline();
+  }
+
+  /**
+   * Marks a always on device online.
+   * @private
+   */
+  async _markAlwaysOnDeviceOnline() {
+    if (this.alwaysOnDeviceOfflineTimer) {
+      this.alwaysOnDeviceRetryCount = 0;
+      if (!this.getAvailable()) {
+        this.log('Device is now online', this.getName());
+        await this.setAvailable();
+      }
+    }
+  }
+
+  /**
+   * Marks a sleepy end device online.
+   * @private
+   */
+  async _markSleepyDeviceOnline() {
+    if (this.sleepyDeviceOfflineTimer) {
+      this._startSleepyDeviceOfflineMonitor(this.sleepyDeviceCheckInterval);
+      if (!this.getAvailable()) {
+        this.log('Device is now online', this.getName());
+        await this.setAvailable();
+      }
+    }
+  }
+
+  /**
+   * Stops monitoring a always on device for offline status.
+   */
+  stopAlwaysOnDeviceOfflineMonitor() {
+    if (this.alwaysOnDeviceOfflineTimer) {
+      this.homey.clearInterval(this.alwaysOnDeviceOfflineTimer);
+      this.alwaysOnDeviceOfflineTimer = null;
+    }
+  }
+
+  /**
+   * Stops monitoring a sleepy device for offline status.
+   */
+  stopSleepyDeviceOfflineMonitor() {
+    if (this.sleepyDeviceOfflineTimer) {
+      this.homey.clearTimeout(this.sleepyDeviceOfflineTimer);
+      this.sleepyDeviceOfflineTimer = null;
+    }
+  }
+
+  /**
+   * Attaches a frame listener for online check. This overrides the node's
+   * handleFrame function to also mark the device online when a frame is received.
+   * @private
+   */
+  async _attachOnlineCheckListener() {
+    if (!this._isAttachOnlineListener) {
+      this._isAttachOnlineListener = true;
+      const node = await this.homey.zigbee.getNode(this);
+      this.originalHandleFrame = node.handleFrame;
+      // override handle frame for online state
+      this.log('override handle frame for online check');
+      node.handleFrame = async (endpointId, clusterId, frame, meta) => {
+        if (typeof this.originalHandleFrame === 'function') {
+          this.originalHandleFrame.call(node, endpointId, clusterId, frame, meta);
+        }
+        this.markDeviceOnline().catch(err => {
+          this.error('Error in markDeviceOnline:', err);
+        });
+      };
+    }
+  }
+
+  /**
+   * Detaches the online check listener and restores the original handleFrame.
+   * @private
+   */
+  async _detachOnlineCheckListener() {
+    if (this._isAttachOnlineListener) {
+      this._isAttachOnlineListener = false;
+      if (!this.originalHandleFrame) {
+        this.error('No original handleFrame to restore.');
+        return;
+      }
+      const node = await this.homey.zigbee.getNode(this);
+      this.log('restore original handle frame');
+      node.handleFrame = this.originalHandleFrame;
+      this.originalHandleFrame = null;
+    }
+  }
+
+  /**
+   * Starts a monitor to check if a sleepy Zigbee device is offline.
+   * Uses either configured attribute reporting or a simple timer.
+   * @param {number} intervalSeconds - Offline check interval in seconds (>= 60).
+   * @param {number} [retryCount] - Number of missed checks before offline.
+   * @param {ClusterSpecification} [reportingCluster] - Cluster for attribute reporting.
+   * @param {string} [reportingAttributeName] - Attribute name for reporting.
+   */
+  async startSleepyDeviceOfflineMonitor(intervalSeconds,
+    retryCount = DEFAULT_SLEEPY_DEVICE_CHECK_COUNT,
+    reportingCluster = null,
+    reportingAttributeName = null) {
+    if (this.driver.manifest.zigbee?.livenessOwner !== 'app') {
+      this.error('no liveness manifest');
+      return;
+    }
+    if (typeof intervalSeconds !== 'number' || intervalSeconds < MIN_INTERVAL_SECONDS
+      || typeof retryCount !== 'number' || retryCount <= 0) {
+      this.error('Interval or retry count is invalid.');
+      return;
+    }
+    if ((reportingCluster && !reportingAttributeName)npm
+      || (!reportingCluster && reportingAttributeName)) {
+      this.error('reportingCluster, reportingAttributeName should provide both');
+      return;
+    }
+
+    this._lastUpdateTime = 0;
+    this.sleepyDeviceCheckInterval = (intervalSeconds * retryCount
+      + SLEEPY_DEVICE_INTERVAL_MARGIN_SEC) * 1000;
+    await this._attachOnlineCheckListener();
+
+    if (!reportingCluster && !reportingAttributeName) {
+      this._startSleepyDeviceOfflineMonitor(this.sleepyDeviceCheckInterval);
+      return;
+    }
+
+    assertClusterSpecification(reportingCluster);
+
+    // get info from this.getStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY)
+    const clusterAttributeData = this._findReportingAttributeInfo(reportingCluster.NAME,
+      reportingAttributeName);
+    if (!clusterAttributeData || clusterAttributeData.length === 0) {
+      // configure attribute reporting if no data stored
+      const clusterEndpoint = this.getClusterEndpoint(reportingCluster);
+      if (typeof clusterEndpoint === 'number') {
+        try {
+          await this.configureAttributeReporting([{
+            endpointId: clusterEndpoint,
+            cluster: reportingCluster,
+            attributeName: reportingAttributeName,
+            minInterval: ATTRIBUTE_REPORTING_CONFIGURATION_DEFAULTS.minInterval,
+            maxInterval: intervalSeconds,
+            minChange: ATTRIBUTE_REPORTING_CONFIGURATION_DEFAULTS.minChange,
+          }]);
+        } catch (err) {
+          this.error('configure reporting attribute fail ', err);
+        }
+      }
+    }
+    this._startSleepyDeviceOfflineMonitor(this.sleepyDeviceCheckInterval);
+  }
+
+  /**
+   * Starts the offline timer.
+   * @param {number} interval - Time in milliseconds until offline.
+   * @private
+   */
+  _startSleepyDeviceOfflineMonitor(interval) {
+    this.stopSleepyDeviceOfflineMonitor();
+    this.sleepyDeviceOfflineTimer = this.homey.setTimeout(async () => {
+      try {
+        await this.setUnavailable();
+        this.log('Device is offline ', this.getName());
+      } catch (error) {
+        this.error('Error setting device to unavailable', error);
+      }
+    }, interval);
+  }
+
+  /**
+   * Finds and returns the reporting cluster with attribute information.
+   * @param {string} clusterName - The name of the cluster to search for.
+   * @param {string} attributeName - The name of the attribute to search for.
+   * @returns {Object|null} The reporting attribute information if found, otherwise null.
+   * @private
+   */
+  _findReportingAttributeInfo(clusterName, attributeName) {
+    const data = this.getStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY);
+    for (const item of data) {
+      const keys = Object.keys(item); // Get the keys of the object
+      for (const key of keys) { // Iterate over the keys array
+        if (item[key].clusterName === clusterName && item[key].attributeName === attributeName) {
+          return item[key];
+        }
+      }
+    }
+    return null;
   }
 
 }


### PR DESCRIPTION
This pull request introduces a feature for monitoring the liveness (offline detection) of Zigbee devices, categorized into Sleepy and Always-on devices.

Always-on devices: The implementation periodically requests data from the Basic Cluster. If the data cannot be read, the device is marked as offline after a default of 10 minutes, with a maximum of two attempts (20 minutes total).

Sleepy devices: For these devices, if data is not received based on the reporting attribute's maximum interval and the retry count, the device will be marked as offline. Additionally, if a device does not support reporting settings, it will still be marked as offline if no data is received within the specified interval.

I also made a slight modification regarding the CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY. When storing more than one value, the data appears to be wrapped in an array. I adjusted this behavior, and I would appreciate review on this change.
The previous behavior seemed to produce data structured like this:
{
   "0": {  "measuredValue": {...} },
  "onOff": {...}
 }

Thank you for your time and feedback!