### PR TITLE
feat: Add function for Zigbee device liveness monitoring

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -1424,13 +1424,17 @@ class ZigBeeDevice extends Homey.Device {
     cluster = DEFAULT_CLUSTER_PING,
     attribute = DEFAULT_ATTRIBUTE_PING,
   ) {
+    if (!this._isSupportOfflineMonitoring()) {
+      this.error('Offline monitoring does not work in the current platform version.');
+      return;
+    }
+
     this.assertIntervals(intervalSeconds);
     this.assertRetryCount(retryCount);
 
     const pingEndpoint = endpoint === UNSET_ENDPOINT ? this.getClusterEndpoint(cluster) : endpoint;
     assertZCLNode(this.zclNode, pingEndpoint, cluster);
 
-    await this.setLivenessSetting();
     this._attachFrameListener();
     this.stopPingOfflineMonitor();
 
@@ -1539,11 +1543,14 @@ class ZigBeeDevice extends Homey.Device {
     reportingCluster,
     reportingAttributeName,
   ) {
+    if (!this._isSupportOfflineMonitoring()) {
+      this.error('Offline monitoring does not work in the current platform version.');
+      return;
+    }
     this.assertIntervals(intervalSeconds);
     this.assertRetryCount(retryCount);
     assertZCLNode(this.zclNode, reportingEndpoint, reportingCluster);
 
-    await this.setLivenessSetting();
     this._attachFrameListener();
 
     // get info from this.getStoreValue(CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY)
@@ -1617,7 +1624,10 @@ class ZigBeeDevice extends Homey.Device {
    */
   async configureOfflineTimeout(intervalSeconds) {
     this.assertIntervals(intervalSeconds);
-    await this.setLivenessSetting();
+    if (!this._isSupportOfflineMonitoring()) {
+      this.error('Offline monitoring does not work in the current platform version.');
+      return;
+    }
     this._attachFrameListener();
     this.offlineCheckInterval = intervalSeconds;
     this.startOfflineTimeout(this.offlineCheckInterval);
@@ -1642,11 +1652,16 @@ class ZigBeeDevice extends Homey.Device {
   }
 
   /**
-   * Sets the liveness(offline check) setting to app.
+   * The offline monitoring only works on platform versions
+   * that provide the setAppHandlesLiveness function.
    * @private
    */
-  async setLivenessSetting() {
-    await this.setSettings({ zb_livenessOwner: 'app' });
+  _isSupportOfflineMonitoring() {
+    if (typeof this.homey.zigbee.setAppHandlesLiveness === 'function') {
+      this.homey.zigbee.setAppHandlesLiveness(this, true);
+      return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces a feature for monitoring the liveness (offline detection) of Zigbee devices, categorized into Sleepy and Always-on devices.

Always-on devices: The implementation periodically requests data from the Basic Cluster. If the data cannot be read, the device is marked as offline after a default of 10 minutes, with a maximum of two attempts (20 minutes total).

Sleepy devices: For these devices, if data is not received based on the reporting attribute's maximum interval and the retry count, the device will be marked as offline. Additionally, if a device does not support reporting settings, it will still be marked as offline if no data is received within the specified interval.

Additional Changes:
I made a slight modification regarding the data of CONFIGURED_ATTRIBUTE_REPORTING_STORE_KEY. When storing more than one value, the data appears to be wrapped in an array. I adjusted this behavior, and I would very appreciate review on this change.
The previous behavior seemed to produce data structured like this:
{
  "0": { "measuredValue": {...} },
  "onOff": {...}
}

Thank you for your time and feedback!