### PR TITLE
Throw error in capability listener

### DIFF
--- a/lib/ZigBeeDevice.js
+++ b/lib/ZigBeeDevice.js
@@ -1232,6 +1232,7 @@ class ZigBeeDevice extends Homey.Device {
       return this.setClusterCapabilityValue(capabilityId, cluster, value, opts)
         .catch(err => {
           this.error(`Error: failed to set cluster capability value (capability: ${capabilityId}, cluster: ${cluster.NAME}, value: ${value})`, err);
+          throw new Error(this.zigbeedriverI18n('error.command_failed'));
         });
     });
   }


### PR DESCRIPTION
Without this throw, the capability change will not be cancelled on error, letting the user believe the action has succeeded while it hasn't.