### PR TITLE
chore: remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@athombv:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
**Closed - superseded by automation.** Kept open initially as a manual pre-clean for the upcoming `@athombv/jsdoc-template` migration to npmjs.org (athombv/jsdoc-template#23), then closed because:

1. Merging this alone breaks `npm ci` here. `package-lock.json` still resolves `@athombv/jsdoc-template` via `https://npm.pkg.github.com/...`; without the `.npmrc` token mapping `npm ci` would 401 on install.
2. The `update-dependents.yaml` workflow in athombv/jsdoc-template#23 does the full transition in one commit per dependent: bumps the version, strips the `@athombv` / `npm.pkg.github.com` lines from `.npmrc` (and removes the file when empty), and regenerates `package-lock.json` so it resolves from npmjs.org.

The automated PR will appear here automatically after athombv/jsdoc-template#23 lands and the first npmjs.org publish runs.