### PR TITLE
feat(zigbee-light-device): Harden the dim readback against transitions

### DIFF
--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -19,7 +19,15 @@ const MAX_DIM = 254;
 const MAX_SATURATION = 254;
 const CIE_MULTIPLIER = 65536;
 const CURRENT_LEVEL = 'currentLevel';
+// A transition time of `0xFFFF` hands the transition to the device, which runs it over its own
+// `onOffTransitionTime`.
+const TRANSITION_TIME_UNSET = 0xFFFF;
+const ON_OFF_TRANSITION_TIME = 'onOffTransitionTime';
 const DIM_READBACK_DELAY = 1000;
+
+// An app can hold many lights that all initialize at once. Spread the (optional)
+// `onOffTransitionTime` read of each of them over this window instead of flooding the network.
+const ON_OFF_TRANSITION_TIME_READ_JITTER = 30000;
 
 // `onoff` and `dim` arrive as separate, unordered capability writes. A dim command this close to
 // an on/off command belongs to the same user action, regardless of which arrived first. Writes
@@ -95,6 +103,27 @@ class ZigBeeLightDevice extends ZigBeeDevice {
 
   /**
    * @private
+   * @type {number} - Timestamp at which the transition started by the last `changeDimLevel` call
+   * is expected to have finished
+   */
+  _dimTransitionEndsAt = 0;
+
+  /**
+   * @private
+   * @type {number} - Counts `changeDimLevel` calls, so a failing one can tell whether the state
+   * it wants to roll back is still its own. Timestamps tie at millisecond resolution.
+   */
+  _dimCommandCount = 0;
+
+  /**
+   * @private
+   * @type {number|null} - The device's own transition time in milliseconds, applied to a dim
+   * command that does not carry a `duration`. `null` as long as it is unknown.
+   */
+  _onOffTransitionTime = null;
+
+  /**
+   * @private
    * @type {Array<{cluster: Cluster, event: string, listener: Function}>}
    */
   _attributeReportListeners = [];
@@ -145,6 +174,8 @@ class ZigBeeLightDevice extends ZigBeeDevice {
       });
     }
 
+    this.scheduleOnOffTransitionTimeRead();
+
     this.registerAttributeReportListeners();
 
     // Register color related capabilities if device has one of the following
@@ -182,6 +213,24 @@ class ZigBeeLightDevice extends ZigBeeDevice {
       min: this.getStoreValue('colorTempMin'),
       max: this.getStoreValue('colorTempMax'),
     };
+  }
+
+  /**
+   * Whether `dim` is backed by a level control cluster on this device.
+   * @returns {boolean}
+   */
+  get hasDimOnLevelControl() {
+    return this.hasCapability('dim') && this.getClusterEndpoint(CLUSTER.LEVEL_CONTROL) !== null;
+  }
+
+  /**
+   * Whether the transition started by the last dim command is still running. `currentLevel` is
+   * then on its way to the requested level, so reading or reporting it yields a level nobody
+   * asked for.
+   * @returns {boolean}
+   */
+  get isDimTransitionRunning() {
+    return Date.now() < this._dimTransitionEndsAt;
   }
 
   get levelControlCluster() {
@@ -254,6 +303,45 @@ class ZigBeeLightDevice extends ZigBeeDevice {
   }
 
   /**
+   * Schedules the {@link readOnOffTransitionTime} read somewhere in the next
+   * {@link ON_OFF_TRANSITION_TIME_READ_JITTER} milliseconds, so that an app with many lights does
+   * not send one read per light the moment it starts.
+   */
+  scheduleOnOffTransitionTimeRead() {
+    if (!this.hasCapability('dim') || this.getClusterEndpoint(CLUSTER.LEVEL_CONTROL) === null) {
+      return;
+    }
+    this.homey.clearTimeout(this._onOffTransitionTimeReadTimeout);
+    this._onOffTransitionTimeReadTimeout = this.homey.setTimeout(
+      () => this.readOnOffTransitionTime(),
+      Math.random() * ON_OFF_TRANSITION_TIME_READ_JITTER,
+    );
+  }
+
+  /**
+   * Reads the transition time the device applies on its own to a `moveToLevelWithOnOff` command
+   * that leaves the transition time up to the device, which is what a dim command without a
+   * `duration` does. Knowing it keeps the dim readback in {@link changeOnOff} from sampling
+   * `currentLevel` halfway such a transition.
+   *
+   * Best effort on purpose: the value only sharpens that guard, so a device that is unreachable,
+   * asleep or does not support the attribute keeps the default and nothing else changes. Never
+   * awaited by the caller.
+   * @returns {Promise<void>}
+   */
+  async readOnOffTransitionTime() {
+    try {
+      const attributes = await this.levelControlCluster.readAttributes([ON_OFF_TRANSITION_TIME]);
+      const onOffTransitionTime = attributes[ON_OFF_TRANSITION_TIME];
+      if (!Number.isFinite(onOffTransitionTime)) return;
+      this._onOffTransitionTime = onOffTransitionTime * 100; // Tenths of a second
+      this.debug(`read ${ON_OFF_TRANSITION_TIME}`, { ms: this._onOffTransitionTime });
+    } catch (err) {
+      this.debug(`could not read ${ON_OFF_TRANSITION_TIME}`, err.message);
+    }
+  }
+
+  /**
    * Listens for `currentLevel` and `onOff` attribute reports and updates the `dim` and `onoff`
    * capability values accordingly.
    *
@@ -262,9 +350,10 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * app rather than chosen here for every light.
    */
   registerAttributeReportListeners() {
-    if (this.hasCapability('dim') && this.getClusterEndpoint(CLUSTER.LEVEL_CONTROL) !== null) {
+    if (this.hasDimOnLevelControl) {
       this._addAttributeReportListener(this.levelControlCluster, `attr.${CURRENT_LEVEL}`, currentLevel => {
         this.debug('attribute report', { currentLevel });
+        if (this.isDimTransitionRunning) return;
         this.setCapabilityValue('dim', limitValue(currentLevel / MAX_DIM, 0, 1)).catch(this.error);
       });
     }
@@ -291,6 +380,7 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * adds a second set while the first keeps firing on a destroyed device.
    */
   async onUninit() {
+    this.homey.clearTimeout(this._onOffTransitionTimeReadTimeout);
     for (const { cluster, event, listener } of this._attributeReportListeners) {
       cluster.removeListener(event, listener);
     }
@@ -366,7 +456,8 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * successfully changing the on/off value, the `dim` capability value will be updated
    * accordingly. Additionally, if the device is turned on, the current dim level will be
    * requested and updated in the form of the `dim` capability value, unless a `dim` command was
-   * issued around the same time, in which case that dim level takes precedence.
+   * issued around the same time or is still transitioning, in which case that dim level takes
+   * precedence.
    * @param {boolean} onoff
    * @returns {Promise<any>}
    */
@@ -376,12 +467,22 @@ class ZigBeeLightDevice extends ZigBeeDevice {
     return this.onOffCluster[onoff ? 'setOn' : 'setOff']()
       .then(async result => {
         if (onoff === false) {
+          // Off ends a dim command from before it, otherwise the next on skips its readback over
+          // a dim level the light no longer holds.
+          if (this._dimCommandAt <= onOffCommandAt) {
+            this._dimCommandAt = 0;
+            this._dimTransitionEndsAt = 0;
+          }
           this.setCapabilityValue('dim', 0).catch(this.error); // Set dim to zero when turned off
         } else if (onoff) {
           // Wait for a little while, some devices do not directly update their currentLevel
           // This read can catch the device mid-transition, an explicit dim command wins. Checked
           // again after the read, a dim command can still come in while it is in flight.
-          const dimCommandWins = () => this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE;
+          // A dim command from the same user action wins, and so does one whose transition is
+          // still running: reading `currentLevel` halfway a fade returns a level the user never
+          // asked for.
+          const dimCommandWins = () => this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE
+            || this.isDimTransitionRunning;
           wait(DIM_READBACK_DELAY)
             .then(async () => {
               if (dimCommandWins()) return;
@@ -413,12 +514,22 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    */
   async changeDimLevel(dim, opts = {}) {
     this.log('changeDimLevel() →', dim);
-    this._dimCommandAt = Date.now();
+    const dimCommand = ++this._dimCommandCount;
+    const dimCommandAt = Date.now();
+    this._dimCommandAt = dimCommandAt;
 
     const moveToLevelWithOnOffCommand = {
       level: Math.round(dim * MAX_DIM),
       transitionTime: calculateLevelControlTransitionTime(opts),
     };
+
+    // Derived from the command, which clamps the duration, so the estimate cannot outlive the
+    // fade. `0xFFFF` hands the transition to the device, which runs it over its own
+    // `onOffTransitionTime`, only known if reading that succeeded.
+    this._dimTransitionEndsAt = dimCommandAt
+      + (moveToLevelWithOnOffCommand.transitionTime === TRANSITION_TIME_UNSET
+        ? this._onOffTransitionTime || 0
+        : moveToLevelWithOnOffCommand.transitionTime * 100);
 
     // Execute dim
     this.debug('changeDimLevel() → ', dim, moveToLevelWithOnOffCommand);
@@ -431,6 +542,15 @@ class ZigBeeLightDevice extends ZigBeeDevice {
           this.setCapabilityValue('onoff', true).catch(this.error);
         }
         return result;
+      })
+      .catch(err => {
+        // The transition never started, so it may not go on guarding the level. Only what this
+        // call set, a dim command that came in since owns the state now.
+        if (this._dimCommandCount === dimCommand) {
+          this._dimCommandAt = 0;
+          this._dimTransitionEndsAt = 0;
+        }
+        throw err;
       });
   }
 
@@ -581,6 +701,9 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * @returns {Promise<void>}
    */
   async onEndDeviceAnnounce() {
+    // A device that was unreachable during init gets another chance here
+    if (this._onOffTransitionTime === null) this.readOnOffTransitionTime();
+
     // Try and get level control cluster
     let levelControlCluster;
     try {

--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -517,6 +517,8 @@ class ZigBeeLightDevice extends ZigBeeDevice {
     return this.onOffCluster[onoff ? 'setOn' : 'setOff']()
       .then(async result => {
         if (onoff === false) {
+          // A readback still pending from an on would write a level the light no longer shows
+          this.homey.clearTimeout(this._dimReadbackTimeout);
           // Off ends a dim command from before it, otherwise the next on skips its readback over
           // a dim level the light no longer holds.
           if (this._dimCommandAt <= onOffCommandAt) {
@@ -525,12 +527,15 @@ class ZigBeeLightDevice extends ZigBeeDevice {
           }
           this.setCapabilityValue('dim', 0).catch(this.error); // Set dim to zero when turned off
         } else if (onoff) {
-          // A dim command from the same user action wins, and so does one still transitioning.
-          const dimCommandWins = () => this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE
+          // The readback is here to find out which level the light restored to, so a light that
+          // is off by the time it runs has nothing to say. A dim command from the same user
+          // action owns the level too, and so does one that is still transitioning.
+          const isReadbackStale = () => this.getCapabilityValue('onoff') === false
+            || this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE
             || this.isDimTransitionRunning;
           // Wait out the ramp to the on level before looking at where the device ended up
           this._scheduleDimReadback(
-            Math.max(DIM_READBACK_DELAY, this.onCommandTransitionTime), dimCommandWins,
+            Math.max(DIM_READBACK_DELAY, this.onCommandTransitionTime), isReadbackStale,
           );
         }
         return result;
@@ -538,33 +543,33 @@ class ZigBeeLightDevice extends ZigBeeDevice {
   }
 
   /**
-   * Reads `currentLevel` after an on/off command and writes it to `dim`, unless a dim command
-   * owns the level by then: it is checked once more after the read, one can come in while the
+   * Reads `currentLevel` after an on/off command and writes it to `dim`, unless something newer
+   * owns the level by then: checked once more after the read, a command can come in while the
    * read is in flight.
    *
    * A device that reports `remainingTime` says how much of its transition is left, so rather
    * than trusting a level sampled halfway, the read is repeated once the device says it stopped.
    * Devices that do not keep the attribute leave it out of the result and get a single read.
    * @param {number} delay - Milliseconds to wait before reading
-   * @param {Function} dimCommandWins - Whether a dim command owns the level
+   * @param {Function} isReadbackStale - Whether something newer owns the level
    * @param {number} [attempt=1]
    * @private
    */
-  _scheduleDimReadback(delay, dimCommandWins, attempt = 1) {
+  _scheduleDimReadback(delay, isReadbackStale, attempt = 1) {
     this.homey.clearTimeout(this._dimReadbackTimeout);
     this._dimReadbackTimeout = this.homey.setTimeout(async () => {
       try {
-        if (dimCommandWins()) return;
+        if (isReadbackStale()) return;
         const { currentLevel, remainingTime } = await this.levelControlCluster.readAttributes([
           CURRENT_LEVEL, REMAINING_TIME,
         ]);
         this.debug('dim readback', { currentLevel, remainingTime, attempt });
-        if (dimCommandWins()) return;
+        if (isReadbackStale()) return;
         if (remainingTime > 0) {
           // Tenths of a second. Out of attempts means the device says this level is still on its
           // way somewhere, so there is nothing here worth writing.
           if (attempt < MAX_DIM_READBACK_ATTEMPTS) {
-            this._scheduleDimReadback(remainingTime * 100, dimCommandWins, attempt + 1);
+            this._scheduleDimReadback(remainingTime * 100, isReadbackStale, attempt + 1);
           }
           return;
         }
@@ -784,8 +789,12 @@ class ZigBeeLightDevice extends ZigBeeDevice {
       ]);
       this.applyTransitionTimes(attributes);
       const { currentLevel } = attributes;
-      this.setCapabilityValue('dim', limitValue(currentLevel / 254, 0, 1)).catch(this.error);
-      this.setCapabilityValue('onoff', limitValue(currentLevel > 0, 0, 1)).catch(this.error);
+      // Both are read off a level that is on its way somewhere while a transition runs, and
+      // `onoff` is the worse of the two: a fade to zero has already set it false.
+      if (!this.isDimTransitionRunning) {
+        this.setCapabilityValue('dim', limitValue(currentLevel / MAX_DIM, 0, 1)).catch(this.error);
+        this.setCapabilityValue('onoff', currentLevel > 0).catch(this.error);
+      }
     } catch (err) {
       // Device does not support the level control cluster, skip
     }

--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -94,6 +94,12 @@ class ZigBeeLightDevice extends ZigBeeDevice {
   _dimCommandAt = 0;
 
   /**
+   * @private
+   * @type {Array<{cluster: Cluster, event: string, listener: Function}>}
+   */
+  _attributeReportListeners = [];
+
+  /**
    * This method will be called when the {@link ZigBeeDevice} instance is ready and did
    * initialize a {@link ZCLNode}.
    *
@@ -138,6 +144,8 @@ class ZigBeeLightDevice extends ZigBeeDevice {
         return this.changeDimLevel(value, opts);
       });
     }
+
+    this.registerAttributeReportListeners();
 
     // Register color related capabilities if device has one of the following
     if (this.hasCapability('light_hue')
@@ -243,6 +251,51 @@ class ZigBeeLightDevice extends ZigBeeDevice {
       .catch(err => {
         this.error('Error: could not read color control attributes', err);
       });
+  }
+
+  /**
+   * Listens for `currentLevel` and `onOff` attribute reports and updates the `dim` and `onoff`
+   * capability values accordingly.
+   *
+   * Reports only arrive if the app binds the cluster in its driver manifest and calls
+   * {@link configureAttributeReporting} itself. Both change the device, so they are left to the
+   * app rather than chosen here for every light.
+   */
+  registerAttributeReportListeners() {
+    if (this.hasCapability('dim') && this.getClusterEndpoint(CLUSTER.LEVEL_CONTROL) !== null) {
+      this._addAttributeReportListener(this.levelControlCluster, `attr.${CURRENT_LEVEL}`, currentLevel => {
+        this.debug('attribute report', { currentLevel });
+        this.setCapabilityValue('dim', limitValue(currentLevel / MAX_DIM, 0, 1)).catch(this.error);
+      });
+    }
+
+    if (this.hasCapability('onoff') && this.getClusterEndpoint(CLUSTER.ON_OFF) !== null) {
+      this._addAttributeReportListener(this.onOffCluster, 'attr.onOff', onOff => {
+        this.debug('attribute report', { onOff });
+        this.setCapabilityValue('onoff', onOff).catch(this.error);
+      });
+    }
+  }
+
+  /**
+   * @private
+   */
+  _addAttributeReportListener(cluster, event, listener) {
+    cluster.on(event, listener);
+    this._attributeReportListeners.push({ cluster, event, listener });
+  }
+
+  /**
+   * The driver caches one {@link ZCLNode} per node, so its clusters outlive this device instance.
+   * Remove the listeners added in {@link registerAttributeReportListeners}, otherwise a re-init
+   * adds a second set while the first keeps firing on a destroyed device.
+   */
+  async onUninit() {
+    for (const { cluster, event, listener } of this._attributeReportListeners) {
+      cluster.removeListener(event, listener);
+    }
+    this._attributeReportListeners = [];
+    return super.onUninit();
   }
 
   /**

--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -9,7 +9,6 @@ const {
   calculateLevelControlTransitionTime,
   calculateColorControlTransitionTime,
   mapTemperatureToHueSaturation,
-  wait,
 } = require('./util');
 
 const ZigBeeDevice = require('./ZigBeeDevice');
@@ -20,14 +19,18 @@ const MAX_SATURATION = 254;
 const CIE_MULTIPLIER = 65536;
 const CURRENT_LEVEL = 'currentLevel';
 // A transition time of `0xFFFF` hands the transition to the device, which runs it over its own
-// `onOffTransitionTime`.
+// `onOffTransitionTime`. `onTransitionTime` holding it means the same for an `On` command.
 const TRANSITION_TIME_UNSET = 0xFFFF;
 const ON_OFF_TRANSITION_TIME = 'onOffTransitionTime';
+const ON_TRANSITION_TIME = 'onTransitionTime';
+const REMAINING_TIME = 'remainingTime';
 const DIM_READBACK_DELAY = 1000;
+// A device that keeps claiming it is still transitioning should not keep the readback going.
+const MAX_DIM_READBACK_ATTEMPTS = 3;
 
-// An app can hold many lights that all initialize at once. Spread the (optional)
-// `onOffTransitionTime` read of each of them over this window instead of flooding the network.
-const ON_OFF_TRANSITION_TIME_READ_JITTER = 30000;
+// An app can hold many lights that all initialize at once. Spread the (optional) transition time
+// read of each of them over this window instead of flooding the network.
+const TRANSITION_TIME_READ_JITTER = 30000;
 
 // `onoff` and `dim` arrive as separate, unordered capability writes. A dim command this close to
 // an on/off command belongs to the same user action, regardless of which arrived first. Writes
@@ -124,6 +127,25 @@ class ZigBeeLightDevice extends ZigBeeDevice {
 
   /**
    * @private
+   * @type {number|null} - The device's own transition time in milliseconds for an `On` command.
+   * `null` when unknown or when the device falls back to {@link _onOffTransitionTime} for it.
+   */
+  _onTransitionTime = null;
+
+  /**
+   * @private
+   * @type {*} - Handle of the pending transition times read
+   */
+  _transitionTimesReadTimeout = null;
+
+  /**
+   * @private
+   * @type {*} - Handle of the pending dim readback
+   */
+  _dimReadbackTimeout = null;
+
+  /**
+   * @private
    * @type {Array<{cluster: Cluster, event: string, listener: Function}>}
    */
   _attributeReportListeners = [];
@@ -174,7 +196,7 @@ class ZigBeeLightDevice extends ZigBeeDevice {
       });
     }
 
-    this.scheduleOnOffTransitionTimeRead();
+    this.scheduleTransitionTimesRead();
 
     this.registerAttributeReportListeners();
 
@@ -303,42 +325,69 @@ class ZigBeeLightDevice extends ZigBeeDevice {
   }
 
   /**
-   * Schedules the {@link readOnOffTransitionTime} read somewhere in the next
-   * {@link ON_OFF_TRANSITION_TIME_READ_JITTER} milliseconds, so that an app with many lights does
-   * not send one read per light the moment it starts.
+   * The transition an `On` command runs at, in milliseconds. Zero as long as neither transition
+   * time is known.
+   * @returns {number}
    */
-  scheduleOnOffTransitionTimeRead() {
-    if (!this.hasCapability('dim') || this.getClusterEndpoint(CLUSTER.LEVEL_CONTROL) === null) {
-      return;
-    }
-    this.homey.clearTimeout(this._onOffTransitionTimeReadTimeout);
-    this._onOffTransitionTimeReadTimeout = this.homey.setTimeout(
-      () => this.readOnOffTransitionTime(),
-      Math.random() * ON_OFF_TRANSITION_TIME_READ_JITTER,
+  get onCommandTransitionTime() {
+    if (this._onTransitionTime !== null) return this._onTransitionTime;
+    return this._onOffTransitionTime || 0;
+  }
+
+  /**
+   * Schedules the {@link readTransitionTimes} read somewhere in the next
+   * {@link TRANSITION_TIME_READ_JITTER} milliseconds, so that an app with many lights does not
+   * send one read per light the moment it starts.
+   */
+  scheduleTransitionTimesRead() {
+    if (!this.hasDimOnLevelControl) return;
+    this.homey.clearTimeout(this._transitionTimesReadTimeout);
+    this._transitionTimesReadTimeout = this.homey.setTimeout(
+      () => this.readTransitionTimes(),
+      Math.random() * TRANSITION_TIME_READ_JITTER,
     );
   }
 
   /**
-   * Reads the transition time the device applies on its own to a `moveToLevelWithOnOff` command
-   * that leaves the transition time up to the device, which is what a dim command without a
-   * `duration` does. Knowing it keeps the dim readback in {@link changeOnOff} from sampling
-   * `currentLevel` halfway such a transition.
+   * Reads the transition times the device applies on its own: `onOffTransitionTime` for a dim
+   * command that leaves the transition up to the device, `onTransitionTime` for an `On` command.
+   * Both keep {@link changeOnOff} from sampling `currentLevel` halfway a transition.
    *
-   * Best effort on purpose: the value only sharpens that guard, so a device that is unreachable,
-   * asleep or does not support the attribute keeps the default and nothing else changes. Never
-   * awaited by the caller.
+   * Best effort on purpose: a device that is unreachable, asleep or does not support the
+   * attributes keeps the defaults and nothing else changes. Never awaited by the caller.
    * @returns {Promise<void>}
    */
-  async readOnOffTransitionTime() {
+  async readTransitionTimes() {
     try {
-      const attributes = await this.levelControlCluster.readAttributes([ON_OFF_TRANSITION_TIME]);
-      const onOffTransitionTime = attributes[ON_OFF_TRANSITION_TIME];
-      if (!Number.isFinite(onOffTransitionTime)) return;
-      this._onOffTransitionTime = onOffTransitionTime * 100; // Tenths of a second
-      this.debug(`read ${ON_OFF_TRANSITION_TIME}`, { ms: this._onOffTransitionTime });
+      this.applyTransitionTimes(await this.levelControlCluster.readAttributes([
+        ON_OFF_TRANSITION_TIME, ON_TRANSITION_TIME,
+      ]));
     } catch (err) {
-      this.debug(`could not read ${ON_OFF_TRANSITION_TIME}`, err.message);
+      this.debug('could not read transition times', err.message);
     }
+  }
+
+  /**
+   * Takes the transition times out of a level control read, which is not necessarily one done
+   * for them: {@link onEndDeviceAnnounce} asks for them alongside `currentLevel`.
+   * @param {object} attributes - Result of a level control `readAttributes`
+   */
+  applyTransitionTimes(attributes) {
+    // Tenths of a second. An attribute the device does not support is missing from the result.
+    if (Number.isFinite(attributes[ON_OFF_TRANSITION_TIME])) {
+      this._onOffTransitionTime = attributes[ON_OFF_TRANSITION_TIME] * 100;
+    }
+    if (Number.isFinite(attributes[ON_TRANSITION_TIME])) {
+      // The sentinel is a value, not an absence: a device that stops having its own transition
+      // for an `On` command has to lose the one it reported before.
+      this._onTransitionTime = attributes[ON_TRANSITION_TIME] === TRANSITION_TIME_UNSET
+        ? null
+        : attributes[ON_TRANSITION_TIME] * 100;
+    }
+    this.debug('transition times', {
+      onOffTransitionTime: this._onOffTransitionTime,
+      onTransitionTime: this._onTransitionTime,
+    });
   }
 
   /**
@@ -380,7 +429,8 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * adds a second set while the first keeps firing on a destroyed device.
    */
   async onUninit() {
-    this.homey.clearTimeout(this._onOffTransitionTimeReadTimeout);
+    this.homey.clearTimeout(this._transitionTimesReadTimeout);
+    this.homey.clearTimeout(this._dimReadbackTimeout);
     for (const { cluster, event, listener } of this._attributeReportListeners) {
       cluster.removeListener(event, listener);
     }
@@ -475,32 +525,55 @@ class ZigBeeLightDevice extends ZigBeeDevice {
           }
           this.setCapabilityValue('dim', 0).catch(this.error); // Set dim to zero when turned off
         } else if (onoff) {
-          // Wait for a little while, some devices do not directly update their currentLevel
-          // This read can catch the device mid-transition, an explicit dim command wins. Checked
-          // again after the read, a dim command can still come in while it is in flight.
-          // A dim command from the same user action wins, and so does one whose transition is
-          // still running: reading `currentLevel` halfway a fade returns a level the user never
-          // asked for.
+          // A dim command from the same user action wins, and so does one still transitioning.
           const dimCommandWins = () => this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE
             || this.isDimTransitionRunning;
-          wait(DIM_READBACK_DELAY)
-            .then(async () => {
-              if (dimCommandWins()) return;
-              // Get current level attribute to update dim level
-              const { currentLevel } = await this.levelControlCluster.readAttributes([
-                CURRENT_LEVEL,
-              ]);
-              this.debug('changeOnOff() →', onoff, { currentLevel });
-              if (dimCommandWins()) return;
-              // Always set dim to 0.01 or higher since bulb is turned on
-              await this.setCapabilityValue('dim', Math.max(0.01, currentLevel / MAX_DIM)).catch(this.error);
-            })
-            .catch(err => {
-              this.error('Error: could not update dim capability value after `onoff` change', err);
-            });
+          // Wait out the ramp to the on level before looking at where the device ended up
+          this._scheduleDimReadback(
+            Math.max(DIM_READBACK_DELAY, this.onCommandTransitionTime), dimCommandWins,
+          );
         }
         return result;
       });
+  }
+
+  /**
+   * Reads `currentLevel` after an on/off command and writes it to `dim`, unless a dim command
+   * owns the level by then: it is checked once more after the read, one can come in while the
+   * read is in flight.
+   *
+   * A device that reports `remainingTime` says how much of its transition is left, so rather
+   * than trusting a level sampled halfway, the read is repeated once the device says it stopped.
+   * Devices that do not keep the attribute leave it out of the result and get a single read.
+   * @param {number} delay - Milliseconds to wait before reading
+   * @param {Function} dimCommandWins - Whether a dim command owns the level
+   * @param {number} [attempt=1]
+   * @private
+   */
+  _scheduleDimReadback(delay, dimCommandWins, attempt = 1) {
+    this.homey.clearTimeout(this._dimReadbackTimeout);
+    this._dimReadbackTimeout = this.homey.setTimeout(async () => {
+      try {
+        if (dimCommandWins()) return;
+        const { currentLevel, remainingTime } = await this.levelControlCluster.readAttributes([
+          CURRENT_LEVEL, REMAINING_TIME,
+        ]);
+        this.debug('dim readback', { currentLevel, remainingTime, attempt });
+        if (dimCommandWins()) return;
+        if (remainingTime > 0) {
+          // Tenths of a second. Out of attempts means the device says this level is still on its
+          // way somewhere, so there is nothing here worth writing.
+          if (attempt < MAX_DIM_READBACK_ATTEMPTS) {
+            this._scheduleDimReadback(remainingTime * 100, dimCommandWins, attempt + 1);
+          }
+          return;
+        }
+        // Always set dim to 0.01 or higher since bulb is turned on
+        await this.setCapabilityValue('dim', Math.max(0.01, currentLevel / MAX_DIM)).catch(this.error);
+      } catch (err) {
+        this.error('Error: could not update dim capability value after `onoff` change', err);
+      }
+    }, delay);
   }
 
   /**
@@ -701,14 +774,16 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * @returns {Promise<void>}
    */
   async onEndDeviceAnnounce() {
-    // A device that was unreachable during init gets another chance here
-    if (this._onOffTransitionTime === null) this.readOnOffTransitionTime();
-
     // Try and get level control cluster
     let levelControlCluster;
     try {
       levelControlCluster = this.levelControlCluster;
-      const { currentLevel } = await levelControlCluster.readAttributes(['currentLevel']);
+      // The transition times ride along, a device unreachable during init gets another chance
+      const attributes = await levelControlCluster.readAttributes([
+        CURRENT_LEVEL, ON_OFF_TRANSITION_TIME, ON_TRANSITION_TIME,
+      ]);
+      this.applyTransitionTimes(attributes);
+      const { currentLevel } = attributes;
       this.setCapabilityValue('dim', limitValue(currentLevel / 254, 0, 1)).catch(this.error);
       this.setCapabilityValue('onoff', limitValue(currentLevel > 0, 0, 1)).catch(this.error);
     } catch (err) {

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -30,7 +30,7 @@ Module.prototype.require = originalRequire;
 
 const {
   changeOnOff, changeDimLevel, registerAttributeReportListeners, onUninit,
-  readOnOffTransitionTime, scheduleOnOffTransitionTimeRead,
+  readTransitionTimes, scheduleTransitionTimesRead,
 } = ZigBeeLightDevice.prototype;
 
 const CURRENT_LEVEL_MID_TRANSITION = 7;
@@ -40,6 +40,8 @@ function createDevice({
   capabilities = ['onoff', 'dim'],
   clusters = ['levelControl', 'onOff'],
   onOffTransitionTime,
+  onTransitionTime,
+  remainingTimes = [],
 } = {}) {
   const device = {
     capabilityValues: [],
@@ -49,6 +51,12 @@ function createDevice({
     _dimTransitionEndsAt: 0,
     _dimCommandCount: 0,
     _onOffTransitionTime: null,
+    _onTransitionTime: null,
+    _transitionTimesReadTimeout: null,
+    _dimReadbackTimeout: null,
+    readTransitionTimes: ZigBeeLightDevice.prototype.readTransitionTimes,
+    applyTransitionTimes: ZigBeeLightDevice.prototype.applyTransitionTimes,
+    _scheduleDimReadback: ZigBeeLightDevice.prototype._scheduleDimReadback,
     homey: {
       setTimeout: (fn, ms) => setTimeout(fn, ms),
       clearTimeout: timeout => clearTimeout(timeout),
@@ -69,8 +77,21 @@ function createDevice({
     levelControlCluster: Object.assign(new EventEmitter(), {
       async readAttributes(attributes) {
         device.readAttributesCalls++;
-        if (attributes.includes('onOffTransitionTime')) return { onOffTransitionTime };
-        return { currentLevel: CURRENT_LEVEL_MID_TRANSITION };
+        // A device leaves an attribute it does not support out of the result
+        const values = {};
+        if (attributes.includes('currentLevel')) {
+          values.currentLevel = CURRENT_LEVEL_MID_TRANSITION;
+        }
+        if (attributes.includes('remainingTime') && remainingTimes.length) {
+          values.remainingTime = remainingTimes.shift();
+        }
+        if (attributes.includes('onOffTransitionTime') && onOffTransitionTime !== undefined) {
+          values.onOffTransitionTime = onOffTransitionTime;
+        }
+        if (attributes.includes('onTransitionTime') && onTransitionTime !== undefined) {
+          values.onTransitionTime = onTransitionTime;
+        }
+        return values;
       },
       async moveToLevelWithOnOff({ level }) {
         device.commands.push({ command: 'moveToLevelWithOnOff', level });
@@ -89,12 +110,19 @@ function createDevice({
       device.capabilityValues.push({ capabilityId, value });
     },
   };
+  // Use the real getters, they decide what counts as a running transition and which transition
+  // time applies
+  for (const name of ['isDimTransitionRunning', 'hasDimOnLevelControl', 'onCommandTransitionTime']) {
+    Object.defineProperty(device, name,
+      Object.getOwnPropertyDescriptor(ZigBeeLightDevice.prototype, name));
+  }
+
   return device;
 }
 
 /** Let the unawaited dim readback promise chain in `changeOnOff` run to completion. */
-async function flush() {
-  mock.timers.tick(DIM_READBACK_DELAY);
+async function flush(ms = DIM_READBACK_DELAY) {
+  mock.timers.tick(ms);
   for (let i = 0; i < 5; i++) {
     await new Promise(resolve => setImmediate(resolve));
   }
@@ -287,6 +315,34 @@ describe('ZigBeeLightDevice', function() {
       assert.strictEqual(device._dimTransitionEndsAt, _dimTransitionEndsAt);
     });
 
+    it('reads again when the device says it is still transitioning', async function() {
+      const device = createDevice({ remainingTimes: [20, 0] });
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.strictEqual(device.readAttributesCalls, 1);
+      assert.deepStrictEqual(device.capabilityValues, []);
+
+      await flush(2000); // The device said two seconds were left
+
+      assert.strictEqual(device.readAttributesCalls, 2);
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
+    });
+
+    it('gives up rather than write a level the device is still moving away from', async function() {
+      const device = createDevice({ remainingTimes: [20, 20, 20, 20, 20] });
+
+      await changeOnOff.call(device, true);
+      await flush();
+      for (let i = 0; i < 4; i++) await flush(2000);
+
+      assert.strictEqual(device.readAttributesCalls, 3);
+      assert.deepStrictEqual(device.capabilityValues, []);
+    });
+
     it('sets `dim` to zero when the light is turned off', async function() {
       const device = createDevice();
 
@@ -296,7 +352,7 @@ describe('ZigBeeLightDevice', function() {
     });
   });
 
-  describe('readOnOffTransitionTime()', function() {
+  describe('readTransitionTimes()', function() {
     beforeEach(function() {
       mock.timers.enable({ apis: ['setTimeout'] });
     });
@@ -308,7 +364,7 @@ describe('ZigBeeLightDevice', function() {
     it('stores the transition time the device applies on its own, in milliseconds', async function() {
       const device = createDevice({ onOffTransitionTime: 50 });
 
-      await readOnOffTransitionTime.call(device);
+      await readTransitionTimes.call(device);
 
       assert.strictEqual(device._onOffTransitionTime, 5000);
     });
@@ -316,7 +372,7 @@ describe('ZigBeeLightDevice', function() {
     it('keeps the transition time unknown when the device does not report one', async function() {
       const device = createDevice({ onOffTransitionTime: undefined });
 
-      await readOnOffTransitionTime.call(device);
+      await readTransitionTimes.call(device);
 
       assert.strictEqual(device._onOffTransitionTime, null);
     });
@@ -327,15 +383,63 @@ describe('ZigBeeLightDevice', function() {
         throw new Error('Timeout');
       };
 
-      await readOnOffTransitionTime.call(device);
+      await readTransitionTimes.call(device);
 
       assert.strictEqual(device._onOffTransitionTime, null);
+    });
+
+    it('reads the transition time of an `On` command when the device has its own', async function() {
+      const device = createDevice({ onOffTransitionTime: 50, onTransitionTime: 20 });
+
+      await readTransitionTimes.call(device);
+
+      assert.strictEqual(device._onTransitionTime, 2000);
+      assert.strictEqual(device.onCommandTransitionTime, 2000);
+    });
+
+    it('falls back to `onOffTransitionTime` when the device has no separate one', async function() {
+      const device = createDevice({ onOffTransitionTime: 50, onTransitionTime: 0xFFFF });
+
+      await readTransitionTimes.call(device);
+
+      assert.strictEqual(device._onTransitionTime, null);
+      assert.strictEqual(device.onCommandTransitionTime, 5000);
+    });
+
+    it('drops its own transition time when the device stops reporting one', async function() {
+      const device = createDevice({ onOffTransitionTime: 50, onTransitionTime: 20 });
+      await readTransitionTimes.call(device);
+      assert.strictEqual(device.onCommandTransitionTime, 2000);
+
+      device.levelControlCluster.readAttributes = async () => ({
+        onOffTransitionTime: 50, onTransitionTime: 0xFFFF,
+      });
+      await readTransitionTimes.call(device);
+
+      assert.strictEqual(device.onCommandTransitionTime, 5000);
+    });
+
+    it('waits for the device to finish ramping before reading `currentLevel`', async function() {
+      const device = createDevice({ onTransitionTime: 50 });
+      await readTransitionTimes.call(device);
+      device.readAttributesCalls = 0;
+
+      await changeOnOff.call(device, true);
+      await flush(); // The old fixed delay is not enough now
+
+      assert.strictEqual(device.readAttributesCalls, 0);
+
+      await flush(4000);
+
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
     });
 
     it('does not read from a device without a dim capability', function() {
       const device = createDevice({ capabilities: ['onoff'] });
 
-      scheduleOnOffTransitionTimeRead.call(device);
+      scheduleTransitionTimesRead.call(device);
       mock.timers.tick(60000);
 
       assert.strictEqual(device.readAttributesCalls, 0);
@@ -343,7 +447,7 @@ describe('ZigBeeLightDevice', function() {
 
     it('does not overwrite `dim` while the device fades over its own transition time', async function() {
       const device = createDevice({ onOffTransitionTime: 80 });
-      await readOnOffTransitionTime.call(device);
+      await readTransitionTimes.call(device);
       device.readAttributesCalls = 0;
 
       await changeDimLevel.call(device, 0.5); // No duration, so the device decides

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -2,13 +2,20 @@
 
 const assert = require('assert');
 const Module = require('module');
+const { EventEmitter } = require('events');
 const {
   describe, it, beforeEach, afterEach, mock,
 } = require('node:test');
 
 // `homey` is not a real module, the apps SDK injects it by patching `Module.prototype.require`.
 // Do the same here so `ZigBeeLightDevice` can be required outside of a Homey app.
-class HomeyBase {}
+class HomeyBase {
+
+  async onUninit() {
+    // The SDK's own `Device.onUninit` is a no-op too
+  }
+
+}
 
 const originalRequire = Module.prototype.require;
 Module.prototype.require = function homeyRequire(...args) {
@@ -21,29 +28,33 @@ const ZigBeeLightDevice = require('../../lib/ZigBeeLightDevice');
 
 Module.prototype.require = originalRequire;
 
-const { changeOnOff, changeDimLevel } = ZigBeeLightDevice.prototype;
+const {
+  changeOnOff, changeDimLevel, registerAttributeReportListeners, onUninit,
+} = ZigBeeLightDevice.prototype;
 
 const CURRENT_LEVEL_MID_TRANSITION = 7;
 const DIM_READBACK_DELAY = 1000;
 
-function createDevice() {
+function createDevice({ capabilities = ['onoff', 'dim'], clusters = ['levelControl', 'onOff'] } = {}) {
   const device = {
     capabilityValues: [],
     commands: [],
     readAttributesCalls: 0,
     _dimCommandAt: 0,
+    _attributeReportListeners: [],
+    _addAttributeReportListener: ZigBeeLightDevice.prototype._addAttributeReportListener,
     log() {},
     debug() {},
     error() {},
-    onOffCluster: {
+    onOffCluster: Object.assign(new EventEmitter(), {
       async setOn() {
         device.commands.push({ command: 'setOn' });
       },
       async setOff() {
         device.commands.push({ command: 'setOff' });
       },
-    },
-    levelControlCluster: {
+    }),
+    levelControlCluster: Object.assign(new EventEmitter(), {
       async readAttributes() {
         device.readAttributesCalls++;
         return { currentLevel: CURRENT_LEVEL_MID_TRANSITION };
@@ -51,6 +62,12 @@ function createDevice() {
       async moveToLevelWithOnOff({ level }) {
         device.commands.push({ command: 'moveToLevelWithOnOff', level });
       },
+    }),
+    hasCapability(capabilityId) {
+      return capabilities.includes(capabilityId);
+    },
+    getClusterEndpoint(cluster) {
+      return clusters.includes(cluster.NAME) ? 1 : null;
     },
     getCapabilityValue() {
       return true;
@@ -164,6 +181,56 @@ describe('ZigBeeLightDevice', function() {
       await changeOnOff.call(device, false);
 
       assert.deepStrictEqual(device.capabilityValues, [{ capabilityId: 'dim', value: 0 }]);
+    });
+  });
+
+  describe('registerAttributeReportListeners()', function() {
+    it('updates `dim` from a `currentLevel` attribute report', async function() {
+      const device = createDevice();
+
+      registerAttributeReportListeners.call(device);
+      device.levelControlCluster.emit('attr.currentLevel', 127);
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.deepStrictEqual(device.capabilityValues, [{ capabilityId: 'dim', value: 127 / 254 }]);
+    });
+
+    it('updates `onoff` from an `onOff` attribute report', async function() {
+      const device = createDevice();
+
+      registerAttributeReportListeners.call(device);
+      device.onOffCluster.emit('attr.onOff', false);
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.deepStrictEqual(device.capabilityValues, [{ capabilityId: 'onoff', value: false }]);
+    });
+
+    it('does not listen for clusters the device does not have', function() {
+      const device = createDevice({ clusters: [] });
+
+      registerAttributeReportListeners.call(device);
+
+      assert.strictEqual(device.levelControlCluster.listenerCount('attr.currentLevel'), 0);
+      assert.strictEqual(device.onOffCluster.listenerCount('attr.onOff'), 0);
+    });
+
+    it('removes its listeners again on uninit', async function() {
+      const device = createDevice();
+
+      registerAttributeReportListeners.call(device);
+      await onUninit.call(device);
+
+      assert.strictEqual(device.levelControlCluster.listenerCount('attr.currentLevel'), 0);
+      assert.strictEqual(device.onOffCluster.listenerCount('attr.onOff'), 0);
+    });
+
+    it('does not listen for capabilities the device does not have', function() {
+      const device = createDevice({ capabilities: ['onoff'] });
+
+      registerAttributeReportListeners.call(device);
+
+      assert.strictEqual(device.levelControlCluster.listenerCount('attr.currentLevel'), 0);
+      assert.strictEqual(device.onOffCluster.listenerCount('attr.onOff'), 1);
     });
   });
 });

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -30,7 +30,7 @@ Module.prototype.require = originalRequire;
 
 const {
   changeOnOff, changeDimLevel, registerAttributeReportListeners, onUninit,
-  readTransitionTimes, scheduleTransitionTimesRead,
+  readTransitionTimes, scheduleTransitionTimesRead, onEndDeviceAnnounce,
 } = ZigBeeLightDevice.prototype;
 
 const CURRENT_LEVEL_MID_TRANSITION = 7;
@@ -103,8 +103,9 @@ function createDevice({
     getClusterEndpoint(cluster) {
       return clusters.includes(cluster.NAME) ? 1 : null;
     },
-    getCapabilityValue() {
-      return true;
+    getCapabilityValue(capabilityId) {
+      const written = device.capabilityValues.filter(v => v.capabilityId === capabilityId).pop();
+      return written ? written.value : true;
     },
     async setCapabilityValue(capabilityId, value) {
       device.capabilityValues.push({ capabilityId, value });
@@ -343,6 +344,22 @@ describe('ZigBeeLightDevice', function() {
       assert.deepStrictEqual(device.capabilityValues, []);
     });
 
+    it('drops a readback for a light that is off by the time it runs', async function() {
+      const device = createDevice({ onOffTransitionTime: 80 });
+      await readTransitionTimes.call(device); // The device ramps over eight seconds
+
+      await changeOnOff.call(device, true);
+      await changeOnOff.call(device, false);
+      await device.setCapabilityValue('onoff', false); // Homey commits this after the listener
+
+      await flush(9000);
+
+      // The off set `dim` to zero, the readback still pending from the on may not undo that
+      assert.deepStrictEqual(device.capabilityValues.filter(v => v.capabilityId === 'dim'), [
+        { capabilityId: 'dim', value: 0 },
+      ]);
+    });
+
     it('sets `dim` to zero when the light is turned off', async function() {
       const device = createDevice();
 
@@ -458,6 +475,30 @@ describe('ZigBeeLightDevice', function() {
 
       assert.deepStrictEqual(device.capabilityValues, []);
       assert.strictEqual(device.readAttributesCalls, 0);
+    });
+  });
+
+  describe('onEndDeviceAnnounce()', function() {
+    it('does not touch `dim` or `onoff` while a dim transition is running', async function() {
+      const device = createDevice();
+
+      // A fade to zero has already set `onoff` false, a level above zero would undo that
+      await changeDimLevel.call(device, 0, { duration: 8000 });
+      device.capabilityValues.length = 0;
+      await onEndDeviceAnnounce.call(device);
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+    });
+
+    it('updates `dim` and `onoff` when no transition is running', async function() {
+      const device = createDevice();
+
+      await onEndDeviceAnnounce.call(device);
+
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+        { capabilityId: 'onoff', value: true },
+      ]);
     });
   });
 

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -30,17 +30,29 @@ Module.prototype.require = originalRequire;
 
 const {
   changeOnOff, changeDimLevel, registerAttributeReportListeners, onUninit,
+  readOnOffTransitionTime, scheduleOnOffTransitionTimeRead,
 } = ZigBeeLightDevice.prototype;
 
 const CURRENT_LEVEL_MID_TRANSITION = 7;
 const DIM_READBACK_DELAY = 1000;
 
-function createDevice({ capabilities = ['onoff', 'dim'], clusters = ['levelControl', 'onOff'] } = {}) {
+function createDevice({
+  capabilities = ['onoff', 'dim'],
+  clusters = ['levelControl', 'onOff'],
+  onOffTransitionTime,
+} = {}) {
   const device = {
     capabilityValues: [],
     commands: [],
     readAttributesCalls: 0,
     _dimCommandAt: 0,
+    _dimTransitionEndsAt: 0,
+    _dimCommandCount: 0,
+    _onOffTransitionTime: null,
+    homey: {
+      setTimeout: (fn, ms) => setTimeout(fn, ms),
+      clearTimeout: timeout => clearTimeout(timeout),
+    },
     _attributeReportListeners: [],
     _addAttributeReportListener: ZigBeeLightDevice.prototype._addAttributeReportListener,
     log() {},
@@ -55,8 +67,9 @@ function createDevice({ capabilities = ['onoff', 'dim'], clusters = ['levelContr
       },
     }),
     levelControlCluster: Object.assign(new EventEmitter(), {
-      async readAttributes() {
+      async readAttributes(attributes) {
         device.readAttributesCalls++;
+        if (attributes.includes('onOffTransitionTime')) return { onOffTransitionTime };
         return { currentLevel: CURRENT_LEVEL_MID_TRANSITION };
       },
       async moveToLevelWithOnOff({ level }) {
@@ -163,6 +176,52 @@ describe('ZigBeeLightDevice', function() {
       assert.strictEqual(device.readAttributesCalls, 0);
     });
 
+    it('does not keep guarding past the transition time the device was given', async function() {
+      const device = createDevice();
+
+      // Out of range, the command clamps it to 65534 tenths of a second
+      await changeDimLevel.call(device, 0.5, { duration: 9000000 });
+
+      assert.strictEqual(device._dimTransitionEndsAt - device._dimCommandAt, 6553400);
+    });
+
+    it('does not overwrite `dim` while the transition of an older dim command is still running', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5, { duration: 8000 });
+      device._dimCommandAt = Date.now() - 5000; // Older than the grace period, still fading
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 0);
+    });
+
+    it('updates `dim` once the transition of the last dim command has finished', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5, { duration: 100 });
+      device._dimCommandAt = Date.now() - 5000;
+      device._dimTransitionEndsAt = Date.now() - 4900;
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
+    });
+
+    it('stops guarding the dim transition once the light is turned off', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5, { duration: 8000 });
+      await changeOnOff.call(device, false);
+
+      assert.strictEqual(device._dimTransitionEndsAt, 0);
+    });
+
     it('updates `dim` when the last dim command is older than the grace period', async function() {
       const device = createDevice();
       device._dimCommandAt = Date.now() - 5000;
@@ -175,6 +234,59 @@ describe('ZigBeeLightDevice', function() {
       ]);
     });
 
+    it('reads the level again when the light was turned off after the dim command', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5);
+      await changeOnOff.call(device, false);
+      device.capabilityValues.length = 0;
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      // The off already set `dim` to zero, so skipping the readback would leave it there
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
+    });
+
+    it('stops guarding the level when the dim command fails', async function() {
+      const device = createDevice();
+      device.levelControlCluster.moveToLevelWithOnOff = async () => {
+        throw new Error('Timeout');
+      };
+
+      await assert.rejects(changeDimLevel.call(device, 0.5, { duration: 8000 }));
+
+      assert.strictEqual(device._dimCommandAt, 0);
+      assert.strictEqual(device._dimTransitionEndsAt, 0);
+    });
+
+    it('leaves a newer dim command alone when an older one fails', async function() {
+      const device = createDevice();
+      let failFirstCommand;
+      const firstCommandSent = new Promise(resolve => {
+        device.levelControlCluster.moveToLevelWithOnOff = async () => {
+          resolve();
+          await new Promise(fail => {
+            failFirstCommand = fail;
+          });
+          throw new Error('Timeout');
+        };
+      });
+
+      const failing = changeDimLevel.call(device, 0.5, { duration: 8000 });
+      await firstCommandSent;
+      device.levelControlCluster.moveToLevelWithOnOff = async () => {};
+      await changeDimLevel.call(device, 0.8, { duration: 8000 });
+      const { _dimCommandAt, _dimTransitionEndsAt } = device;
+      failFirstCommand();
+      await assert.rejects(failing);
+
+      assert.strictEqual(device._dimCommandAt, _dimCommandAt);
+      assert.strictEqual(device._dimTransitionEndsAt, _dimTransitionEndsAt);
+    });
+
     it('sets `dim` to zero when the light is turned off', async function() {
       const device = createDevice();
 
@@ -184,11 +296,97 @@ describe('ZigBeeLightDevice', function() {
     });
   });
 
+  describe('readOnOffTransitionTime()', function() {
+    beforeEach(function() {
+      mock.timers.enable({ apis: ['setTimeout'] });
+    });
+
+    afterEach(function() {
+      mock.timers.reset();
+    });
+
+    it('stores the transition time the device applies on its own, in milliseconds', async function() {
+      const device = createDevice({ onOffTransitionTime: 50 });
+
+      await readOnOffTransitionTime.call(device);
+
+      assert.strictEqual(device._onOffTransitionTime, 5000);
+    });
+
+    it('keeps the transition time unknown when the device does not report one', async function() {
+      const device = createDevice({ onOffTransitionTime: undefined });
+
+      await readOnOffTransitionTime.call(device);
+
+      assert.strictEqual(device._onOffTransitionTime, null);
+    });
+
+    it('keeps the transition time unknown when the device cannot be reached', async function() {
+      const device = createDevice();
+      device.levelControlCluster.readAttributes = async () => {
+        throw new Error('Timeout');
+      };
+
+      await readOnOffTransitionTime.call(device);
+
+      assert.strictEqual(device._onOffTransitionTime, null);
+    });
+
+    it('does not read from a device without a dim capability', function() {
+      const device = createDevice({ capabilities: ['onoff'] });
+
+      scheduleOnOffTransitionTimeRead.call(device);
+      mock.timers.tick(60000);
+
+      assert.strictEqual(device.readAttributesCalls, 0);
+    });
+
+    it('does not overwrite `dim` while the device fades over its own transition time', async function() {
+      const device = createDevice({ onOffTransitionTime: 80 });
+      await readOnOffTransitionTime.call(device);
+      device.readAttributesCalls = 0;
+
+      await changeDimLevel.call(device, 0.5); // No duration, so the device decides
+      device._dimCommandAt = Date.now() - 5000; // Older than the grace period, still fading
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 0);
+    });
+  });
+
   describe('registerAttributeReportListeners()', function() {
     it('updates `dim` from a `currentLevel` attribute report', async function() {
       const device = createDevice();
 
       registerAttributeReportListeners.call(device);
+      device.levelControlCluster.emit('attr.currentLevel', 127);
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.deepStrictEqual(device.capabilityValues, [{ capabilityId: 'dim', value: 127 / 254 }]);
+    });
+
+    it('ignores a `currentLevel` attribute report from halfway a dim transition', async function() {
+      const device = createDevice();
+      registerAttributeReportListeners.call(device);
+
+      await changeDimLevel.call(device, 0.5, { duration: 8000 });
+      device.capabilityValues.length = 0;
+      device.levelControlCluster.emit('attr.currentLevel', 40);
+      await new Promise(resolve => setImmediate(resolve));
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+    });
+
+    it('updates `dim` from a `currentLevel` attribute report once the transition has finished', async function() {
+      const device = createDevice();
+      registerAttributeReportListeners.call(device);
+
+      await changeDimLevel.call(device, 0.5, { duration: 8000 });
+      device.capabilityValues.length = 0;
+      device._dimTransitionEndsAt = Date.now() - 1;
       device.levelControlCluster.emit('attr.currentLevel', 127);
       await new Promise(resolve => setImmediate(resolve));
 


### PR DESCRIPTION
Stacked on #188, which fixes the reported case: a dim command from the same user action wins over the readback. This carries what testing that on hardware turned up, in four commits that each stand on their own.

### What it adds

- **Attribute reports.** `currentLevel` and `onOff` reports update the capabilities, the only self-correcting mechanism here. They fire only if the app binds the cluster and calls `configureAttributeReporting`, which is left to the app because both change the device.
- **Transitions.** The grace period only knows when a dim command started, not how long it runs, so a dim with a transition still lost to the readback. The expected end of the transition is remembered and guards both the readback and the report listener.
- **Waiting for the device.** `onTransitionTime` and `onOffTransitionTime`, read once at init behind a random delay so an app with many lights does not read them all at once, say how long a light ramps by default. `remainingTime` comes back in the readback itself and is the device counting down whatever is running right now, which also covers a transition started by a scene, a group command or a wall remote. All optional: a device that answers none keeps the old one second delay.
- **Off.** An off ends the dim command before it and cancels a readback still pending from an on, and the readback checks the light is still on before writing. Without that an on followed by an off left the light dark with `dim` at 0.21.
- **A transition that never started.** A `moveToLevelWithOnOff` that fails rolls its guard back instead of suppressing updates for the duration of a fade that is not happening.

### Measured

INNR RB 162, driven over the API. Every row is wrong before this PR and right after:

| | before | after |
|---|---|---|
| `onoff` + `dim` with an 8 s transition | 0.03 to 0.11 (6/6) | 0.5 (11/11) |
| `dim` with an 8 s transition ~3.8 s before `onoff` | 0.30 (3/3) | 0.5 (5/5) |
| same, device fading over its own `onOffTransitionTime` | 0.27 | 0.5 |
| standalone `onoff`, device ramping over 8 s | 0.01, light settled at 0.03 | 0.03 |
| same, ramp length unknown to the app | 0.07, sampled 1 s in | 0.5, `remainingTime` said 6.9 s were left |
| `onoff` on, then off 3.4 s later | 0.21 with the light dark | 0 |

The attribute report path is the one thing not verified on hardware: it needs an app that declares the binding, and the app used for this does not.

### Known limits

- The transition times are read at init and on an announce, so a device that changes one in between keeps the old value.
- The dim guard estimates rather than asks: it answers synchronously, and reading `remainingTime` per dim command would put a frame on the air for every step of a slider.
- Ordering between an off and a dim uses timestamps, which tie at millisecond resolution. What survives a tie is one stale dim sample that the next report corrects. Identity does not: rolling back a failed command compares a counter, because that has to be exact.