### PR TITLE
ci: Update the GitHub Actions to their current majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # Checks out the current repository.
       - name: Checkout git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           # The token below is only necessary if you want to push the version bump to a protected branch
           token: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
 
       # Configures a Node.js environment.
       - name: Set up node 24 environment
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,10 @@ jobs:
     name: Build & Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '24'
         registry-url: https://npm.pkg.github.com
@@ -45,7 +45,7 @@ jobs:
         
     # Deploy
     - name: Deploy To GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3.8.0
+      uses: peaceiris/actions-gh-pages@v4
       with:
         personal_token: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
         publish_dir: ./build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
 
       # Checks out the current repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       # Configures a Node.js environment.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       # Checks out the current repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       # Configures a Node.js environment.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: https://npm.pkg.github.com


### PR DESCRIPTION
`actions/checkout` was still on v2 in all four workflows, and `actions/setup-node` sat on three different majors across them (v4 in lint, test and docs, v5 in deploy). Both go to v7, and the docs deploy to `peaceiris/actions-gh-pages@v4`.

No behavior change intended: the Node version, triggers and steps are untouched. The checkout and setup-node majors since v2 mainly move the action runtime forward, which is what matters here since the older runtimes are retired.