### PR TITLE
fix(zigbee-light-device): Do not let the dim readback overwrite an explicit dim

### DIFF
--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -19,6 +19,11 @@ const MAX_DIM = 254;
 const MAX_SATURATION = 254;
 const CIE_MULTIPLIER = 65536;
 const CURRENT_LEVEL = 'currentLevel';
+const DIM_READBACK_DELAY = 1000;
+
+// `onoff` and `dim` arrive as separate, unordered capability writes. A dim command this close to
+// an on/off command belongs to the same user action, regardless of which arrived first.
+const DIM_COMMAND_GRACE = 300;
 
 /**
  * `light_hue` capability configuration used for {@link registerMultipleCapabilities}.
@@ -80,6 +85,12 @@ const lightModeCapabilityDefinition = {
  * }
  */
 class ZigBeeLightDevice extends ZigBeeDevice {
+
+  /**
+   * @private
+   * @type {number} - Timestamp of the last `changeDimLevel` call
+   */
+  _dimCommandAt = 0;
 
   /**
    * This method will be called when the {@link ZigBeeDevice} instance is ready and did
@@ -300,25 +311,32 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    * Sends a `setOn` or `setOff` command to the device in order to turn it on or off. After
    * successfully changing the on/off value, the `dim` capability value will be updated
    * accordingly. Additionally, if the device is turned on, the current dim level will be
-   * requested and updated in the form of the `dim` capability value.
+   * requested and updated in the form of the `dim` capability value, unless a `dim` command was
+   * issued around the same time, in which case that dim level takes precedence.
    * @param {boolean} onoff
    * @returns {Promise<any>}
    */
   async changeOnOff(onoff) {
     this.log('changeOnOff() →', onoff);
+    const onOffCommandAt = Date.now();
     return this.onOffCluster[onoff ? 'setOn' : 'setOff']()
       .then(async result => {
         if (onoff === false) {
           this.setCapabilityValue('dim', 0).catch(this.error); // Set dim to zero when turned off
         } else if (onoff) {
           // Wait for a little while, some devices do not directly update their currentLevel
-          wait(1000)
+          wait(DIM_READBACK_DELAY)
             .then(async () => {
               // Get current level attribute to update dim level
               const { currentLevel } = await this.levelControlCluster.readAttributes([
                 CURRENT_LEVEL,
               ]);
               this.debug('changeOnOff() →', onoff, { currentLevel });
+              // This read can catch the device mid-transition, an explicit dim command wins
+              if (this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE) {
+                this.debug('changeOnOff() →', onoff, 'skipped dim readback, dim command wins');
+                return;
+              }
               // Always set dim to 0.01 or higher since bulb is turned on
               await this.setCapabilityValue('dim', Math.max(0.01, currentLevel / MAX_DIM)).catch(this.error);
             })
@@ -341,6 +359,7 @@ class ZigBeeLightDevice extends ZigBeeDevice {
    */
   async changeDimLevel(dim, opts = {}) {
     this.log('changeDimLevel() →', dim);
+    this._dimCommandAt = Date.now();
 
     const moveToLevelWithOnOffCommand = {
       level: Math.round(dim * MAX_DIM),

--- a/lib/ZigBeeLightDevice.js
+++ b/lib/ZigBeeLightDevice.js
@@ -22,8 +22,9 @@ const CURRENT_LEVEL = 'currentLevel';
 const DIM_READBACK_DELAY = 1000;
 
 // `onoff` and `dim` arrive as separate, unordered capability writes. A dim command this close to
-// an on/off command belongs to the same user action, regardless of which arrived first.
-const DIM_COMMAND_GRACE = 300;
+// an on/off command belongs to the same user action, regardless of which arrived first. Writes
+// fired simultaneously over the API have been measured to land up to ~300ms apart.
+const DIM_COMMAND_GRACE = 500;
 
 /**
  * `light_hue` capability configuration used for {@link registerMultipleCapabilities}.
@@ -325,18 +326,18 @@ class ZigBeeLightDevice extends ZigBeeDevice {
           this.setCapabilityValue('dim', 0).catch(this.error); // Set dim to zero when turned off
         } else if (onoff) {
           // Wait for a little while, some devices do not directly update their currentLevel
+          // This read can catch the device mid-transition, an explicit dim command wins. Checked
+          // again after the read, a dim command can still come in while it is in flight.
+          const dimCommandWins = () => this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE;
           wait(DIM_READBACK_DELAY)
             .then(async () => {
+              if (dimCommandWins()) return;
               // Get current level attribute to update dim level
               const { currentLevel } = await this.levelControlCluster.readAttributes([
                 CURRENT_LEVEL,
               ]);
               this.debug('changeOnOff() →', onoff, { currentLevel });
-              // This read can catch the device mid-transition, an explicit dim command wins
-              if (this._dimCommandAt > onOffCommandAt - DIM_COMMAND_GRACE) {
-                this.debug('changeOnOff() →', onoff, 'skipped dim readback, dim command wins');
-                return;
-              }
+              if (dimCommandWins()) return;
               // Always set dim to 0.01 or higher since bulb is turned on
               await this.setCapabilityValue('dim', Math.max(0.01, currentLevel / MAX_DIM)).catch(this.error);
             })

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -27,13 +27,10 @@ const CURRENT_LEVEL_MID_TRANSITION = 7;
 const DIM_READBACK_DELAY = 1000;
 
 function createDevice() {
-  let resolveReadAttributes;
   const device = {
     capabilityValues: [],
     commands: [],
-    readAttributesCalled: new Promise(resolve => {
-      resolveReadAttributes = resolve;
-    }),
+    readAttributesCalls: 0,
     _dimCommandAt: 0,
     log() {},
     debug() {},
@@ -48,7 +45,7 @@ function createDevice() {
     },
     levelControlCluster: {
       async readAttributes() {
-        resolveReadAttributes();
+        device.readAttributesCalls++;
         return { currentLevel: CURRENT_LEVEL_MID_TRANSITION };
       },
       async moveToLevelWithOnOff({ level }) {
@@ -66,10 +63,9 @@ function createDevice() {
 }
 
 /** Let the unawaited dim readback promise chain in `changeOnOff` run to completion. */
-async function flush(device) {
+async function flush() {
   mock.timers.tick(DIM_READBACK_DELAY);
-  await device.readAttributesCalled;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 5; i++) {
     await new Promise(resolve => setImmediate(resolve));
   }
 }
@@ -88,7 +84,7 @@ describe('ZigBeeLightDevice', function() {
       const device = createDevice();
 
       await changeOnOff.call(device, true);
-      await flush(device);
+      await flush();
 
       assert.deepStrictEqual(device.capabilityValues, [
         { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
@@ -100,13 +96,14 @@ describe('ZigBeeLightDevice', function() {
 
       await changeDimLevel.call(device, 0.5);
       await changeOnOff.call(device, true);
-      await flush(device);
+      await flush();
 
       assert.deepStrictEqual(device.commands, [
         { command: 'moveToLevelWithOnOff', level: 127 },
         { command: 'setOn' },
       ]);
       assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 0);
     });
 
     it('does not overwrite `dim` when a dim command was issued after the on/off command', async function() {
@@ -115,9 +112,38 @@ describe('ZigBeeLightDevice', function() {
       const onOffPromise = changeOnOff.call(device, true);
       await changeDimLevel.call(device, 0.5);
       await onOffPromise;
-      await flush(device);
+      await flush();
 
       assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 0);
+    });
+
+    it('does not overwrite `dim` when a dim command arrives while the readback is in flight', async function() {
+      const device = createDevice();
+      const { readAttributes } = device.levelControlCluster;
+      device.levelControlCluster.readAttributes = async (...args) => {
+        await changeDimLevel.call(device, 0.5);
+        return readAttributes(...args);
+      };
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 1);
+    });
+
+    it('does not overwrite `dim` when a dim command landed just before the grace period ends', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5);
+      device._dimCommandAt = Date.now() - 400; // Simultaneous API writes land this far apart
+
+      await changeOnOff.call(device, true);
+      await flush();
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+      assert.strictEqual(device.readAttributesCalls, 0);
     });
 
     it('updates `dim` when the last dim command is older than the grace period', async function() {
@@ -125,7 +151,7 @@ describe('ZigBeeLightDevice', function() {
       device._dimCommandAt = Date.now() - 5000;
 
       await changeOnOff.call(device, true);
-      await flush(device);
+      await flush();
 
       assert.deepStrictEqual(device.capabilityValues, [
         { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },

--- a/test/lib/ZigBeeLightDevice.js
+++ b/test/lib/ZigBeeLightDevice.js
@@ -1,0 +1,143 @@
+'use strict';
+
+const assert = require('assert');
+const Module = require('module');
+const {
+  describe, it, beforeEach, afterEach, mock,
+} = require('node:test');
+
+// `homey` is not a real module, the apps SDK injects it by patching `Module.prototype.require`.
+// Do the same here so `ZigBeeLightDevice` can be required outside of a Homey app.
+class HomeyBase {}
+
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function homeyRequire(...args) {
+  if (args[0] === 'homey') return { Device: HomeyBase, Driver: HomeyBase };
+  return originalRequire.apply(this, args);
+};
+
+// eslint-disable-next-line import/order
+const ZigBeeLightDevice = require('../../lib/ZigBeeLightDevice');
+
+Module.prototype.require = originalRequire;
+
+const { changeOnOff, changeDimLevel } = ZigBeeLightDevice.prototype;
+
+const CURRENT_LEVEL_MID_TRANSITION = 7;
+const DIM_READBACK_DELAY = 1000;
+
+function createDevice() {
+  let resolveReadAttributes;
+  const device = {
+    capabilityValues: [],
+    commands: [],
+    readAttributesCalled: new Promise(resolve => {
+      resolveReadAttributes = resolve;
+    }),
+    _dimCommandAt: 0,
+    log() {},
+    debug() {},
+    error() {},
+    onOffCluster: {
+      async setOn() {
+        device.commands.push({ command: 'setOn' });
+      },
+      async setOff() {
+        device.commands.push({ command: 'setOff' });
+      },
+    },
+    levelControlCluster: {
+      async readAttributes() {
+        resolveReadAttributes();
+        return { currentLevel: CURRENT_LEVEL_MID_TRANSITION };
+      },
+      async moveToLevelWithOnOff({ level }) {
+        device.commands.push({ command: 'moveToLevelWithOnOff', level });
+      },
+    },
+    getCapabilityValue() {
+      return true;
+    },
+    async setCapabilityValue(capabilityId, value) {
+      device.capabilityValues.push({ capabilityId, value });
+    },
+  };
+  return device;
+}
+
+/** Let the unawaited dim readback promise chain in `changeOnOff` run to completion. */
+async function flush(device) {
+  mock.timers.tick(DIM_READBACK_DELAY);
+  await device.readAttributesCalled;
+  for (let i = 0; i < 3; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+}
+
+describe('ZigBeeLightDevice', function() {
+  describe('changeOnOff()', function() {
+    beforeEach(function() {
+      mock.timers.enable({ apis: ['setTimeout'] });
+    });
+
+    afterEach(function() {
+      mock.timers.reset();
+    });
+
+    it('updates `dim` from the read `currentLevel` when the light is only turned on', async function() {
+      const device = createDevice();
+
+      await changeOnOff.call(device, true);
+      await flush(device);
+
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
+    });
+
+    it('does not overwrite `dim` when a dim command was issued before the on/off command', async function() {
+      const device = createDevice();
+
+      await changeDimLevel.call(device, 0.5);
+      await changeOnOff.call(device, true);
+      await flush(device);
+
+      assert.deepStrictEqual(device.commands, [
+        { command: 'moveToLevelWithOnOff', level: 127 },
+        { command: 'setOn' },
+      ]);
+      assert.deepStrictEqual(device.capabilityValues, []);
+    });
+
+    it('does not overwrite `dim` when a dim command was issued after the on/off command', async function() {
+      const device = createDevice();
+
+      const onOffPromise = changeOnOff.call(device, true);
+      await changeDimLevel.call(device, 0.5);
+      await onOffPromise;
+      await flush(device);
+
+      assert.deepStrictEqual(device.capabilityValues, []);
+    });
+
+    it('updates `dim` when the last dim command is older than the grace period', async function() {
+      const device = createDevice();
+      device._dimCommandAt = Date.now() - 5000;
+
+      await changeOnOff.call(device, true);
+      await flush(device);
+
+      assert.deepStrictEqual(device.capabilityValues, [
+        { capabilityId: 'dim', value: CURRENT_LEVEL_MID_TRANSITION / 254 },
+      ]);
+    });
+
+    it('sets `dim` to zero when the light is turned off', async function() {
+      const device = createDevice();
+
+      await changeOnOff.call(device, false);
+
+      assert.deepStrictEqual(device.capabilityValues, [{ capabilityId: 'dim', value: 0 }]);
+    });
+  });
+});


### PR DESCRIPTION
### The bug

`changeOnOff(true)` reads `currentLevel` a second after `setOn` and writes it to `dim`. `onoff` and `dim` arrive as separate, unordered capability writes, so setting both at once makes that read race the dim command, and a light still on its way returns a level nobody asked for.

Reported on a tunable white bulb sent `onoff: true`, `light_temperature` and `dim: 0.5` at once: the bulb reached 50% and stayed there, Homey showed 3%.

### The fix

`changeDimLevel` records when it ran, and the readback is skipped when a dim command belongs to the same user action. The grace period sits *before* the on/off timestamp, which is what makes the guard independent of which of the two writes arrived first. It runs before the read as well, so a readback that will be discarded no longer puts a command on the air.

500 ms because two writes fired simultaneously were measured landing up to ~306 ms apart on a Homey Pro, just outside the 300 ms this started at.

Cost: dimming and then toggling within the grace skips that one readback, leaving `dim` at the level the dim command asked for. A standalone on/off is unaffected.

### Measured

INNR RB 162, `onoff` and `dim: 0.5` written simultaneously over the API, the bulb given an eight second transition so the readback lands mid-fade:

| before | after |
|---|---|
| `dim` 0.03 to 0.11, wrong in all six runs | 0.5 in every run |

Reproducing this needs a transition. A light that reaches its level immediately gets a readback that happens to return the requested level, so the bug hides.

### Follow-up

This is the reported case only. #184 stacks on it with the rest: attribute reports, transitions the grace period cannot cover, and what an off in between should do.