### PR TITLE
fix(util): Treat a non-finite duration as no duration

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -69,7 +69,9 @@ function limitValue(value, min, max) {
  * @memberof Util
  */
 function calculateLevelControlTransitionTime(opts = {}) {
-  if (typeof opts.duration === 'number') {
+  // `NaN` passes a `typeof` check but not this one, and would end up in the ZCL frame as a
+  // transition time of zero instead of falling back to the device's own default.
+  if (Number.isFinite(opts.duration)) {
     // Convert from milliseconds to tenth of second, then cap the range between 0 and 65534, the
     // full range is 65535 but 0xFFFF does not represent the longest time possible but the time
     // set in `OnOffTransactionTime` attribute.
@@ -92,7 +94,7 @@ function calculateLevelControlTransitionTime(opts = {}) {
  * @memberof Util
  */
 function calculateColorControlTransitionTime(opts = {}) {
-  if (typeof opts.duration === 'number') {
+  if (Number.isFinite(opts.duration)) {
     // Convert from milliseconds to tenth of second, then cap the range between 0 and 65535.
     return Math.max(Math.min(opts.duration / 100, 65535), 0);
   }

--- a/test/lib/util/index.js
+++ b/test/lib/util/index.js
@@ -72,6 +72,7 @@ describe('util', function() {
     const validDuration = calculateLevelControlTransitionTime({ duration: 5000 });
     const validDuration2 = calculateLevelControlTransitionTime({ duration: 0 });
 
+    const nanDuration = calculateLevelControlTransitionTime({ duration: NaN });
     const noDuration = calculateLevelControlTransitionTime();
     const noDuration2 = calculateLevelControlTransitionTime({});
 
@@ -83,6 +84,7 @@ describe('util', function() {
     assert.strictEqual(validDuration, 50);
     assert.strictEqual(validDuration2, 0);
 
+    assert.strictEqual(nanDuration, 0xFFFF);
     assert.strictEqual(noDuration, 0xFFFF);
     assert.strictEqual(noDuration2, 0xFFFF);
 
@@ -94,6 +96,7 @@ describe('util', function() {
     const validDuration = calculateColorControlTransitionTime({ duration: 5000 });
     const validDuration2 = calculateColorControlTransitionTime({ duration: 0 });
 
+    const nanDuration = calculateColorControlTransitionTime({ duration: NaN });
     const noDuration = calculateColorControlTransitionTime();
     const noDuration2 = calculateColorControlTransitionTime({});
 
@@ -105,6 +108,7 @@ describe('util', function() {
     assert.strictEqual(validDuration, 50);
     assert.strictEqual(validDuration2, 0);
 
+    assert.strictEqual(nanDuration, 0);
     assert.strictEqual(noDuration, 0);
     assert.strictEqual(noDuration2, 0);
 


### PR DESCRIPTION
`NaN` passes `typeof duration === 'number'`, so a capability write arriving with `duration: NaN`, which Homey does send, skipped the `0xFFFF` fallback and put `NaN / 100` in the ZCL frame. The device then transitions instantly instead of over its own configured transition time.

`Infinity` changes with it: it used to clamp to 65534 tenths of a second, asking the device for a fade of nearly two hours. An infinite duration is no more a duration than `NaN` is, so both hand the transition back to the device.

Affects the level control and the color control transition time alike.