### PR TITLE
test(util): Cover an infinite transition duration

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -69,8 +69,9 @@ function limitValue(value, min, max) {
  * @memberof Util
  */
 function calculateLevelControlTransitionTime(opts = {}) {
-  // `NaN` passes a `typeof` check but not this one, and would end up in the ZCL frame as a
-  // transition time of zero instead of falling back to the device's own default.
+  // A duration that is not a finite number is not a duration: `NaN` passes a `typeof` check and
+  // would reach the ZCL frame as zero, and clamping an infinite one to the maximum would ask the
+  // device for a transition of nearly two hours. Both fall back to the device's own default.
   if (Number.isFinite(opts.duration)) {
     // Convert from milliseconds to tenth of second, then cap the range between 0 and 65534, the
     // full range is 65535 but 0xFFFF does not represent the longest time possible but the time

--- a/test/lib/util/index.js
+++ b/test/lib/util/index.js
@@ -73,6 +73,7 @@ describe('util', function() {
     const validDuration2 = calculateLevelControlTransitionTime({ duration: 0 });
 
     const nanDuration = calculateLevelControlTransitionTime({ duration: NaN });
+    const infiniteDuration = calculateLevelControlTransitionTime({ duration: Infinity });
     const noDuration = calculateLevelControlTransitionTime();
     const noDuration2 = calculateLevelControlTransitionTime({});
 
@@ -85,6 +86,7 @@ describe('util', function() {
     assert.strictEqual(validDuration2, 0);
 
     assert.strictEqual(nanDuration, 0xFFFF);
+    assert.strictEqual(infiniteDuration, 0xFFFF);
     assert.strictEqual(noDuration, 0xFFFF);
     assert.strictEqual(noDuration2, 0xFFFF);
 
@@ -97,6 +99,7 @@ describe('util', function() {
     const validDuration2 = calculateColorControlTransitionTime({ duration: 0 });
 
     const nanDuration = calculateColorControlTransitionTime({ duration: NaN });
+    const infiniteDuration = calculateColorControlTransitionTime({ duration: Infinity });
     const noDuration = calculateColorControlTransitionTime();
     const noDuration2 = calculateColorControlTransitionTime({});
 
@@ -109,6 +112,7 @@ describe('util', function() {
     assert.strictEqual(validDuration2, 0);
 
     assert.strictEqual(nanDuration, 0);
+    assert.strictEqual(infiniteDuration, 0);
     assert.strictEqual(noDuration, 0);
     assert.strictEqual(noDuration2, 0);
 


### PR DESCRIPTION
#189 moved both transition time helpers to `Number.isFinite`. That changed `Infinity` along with `NaN`: it used to clamp to 65534 tenths of a second, asking the device for a fade of nearly two hours, and now hands the transition back to the device like any other unusable duration.

Deliberate, but the comment mentioned only `NaN` and no test covered it, so nothing would notice a revert to `typeof`. This adds the case for both helpers and says why in the comment. No behaviour change.
