### PR TITLE
fix(deps): Resolve @athombv/data-types from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
     },
     "node_modules/@athombv/data-types": {
       "version": "1.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@athombv/data-types/1.1.3/037d9c66a3af4411e2410e424b08e2aa1c454155",
+      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.1.3.tgz",
       "integrity": "sha512-W95IbuE05ZUn7gNaSmpJorWvaA6YoaAIGrxhQ4wgX7esCeOwLnrEeVtHY7tnMzjEvz1RqK8Quqwo5ZDHXAMiJQ==",
       "dev": true,
       "license": "GPL-3.0",
@@ -5086,7 +5086,7 @@
   "dependencies": {
     "@athombv/data-types": {
       "version": "1.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@athombv/data-types/1.1.3/037d9c66a3af4411e2410e424b08e2aa1c454155",
+      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.1.3.tgz",
       "integrity": "sha512-W95IbuE05ZUn7gNaSmpJorWvaA6YoaAIGrxhQ4wgX7esCeOwLnrEeVtHY7tnMzjEvz1RqK8Quqwo5ZDHXAMiJQ==",
       "dev": true
     },


### PR DESCRIPTION
The deploy workflow fails at `npm ci`:

```
npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@athombv/data-types/1.1.3/...
npm error authentication token not provided
```

`deploy.yml` sets up npm for `registry.npmjs.org`, so the token it has does not apply to GitHub Packages. `test.yml` does not hit this because it sets up for `npm.pkg.github.com` instead.

93d98f8 moved `@athombv/jsdoc-template` from GitHub Packages to npm and removed the `.npmrc` that pointed the whole `@athombv` scope at GitHub Packages. Correct, except its transitive `@athombv/data-types` kept the old resolved URL, so one lockfile entry still points at a registry nothing authenticates against.

Same version, same package, also published on npm, so only `resolved` and `integrity` change. Verified with a clean `npm ci` against `registry.npmjs.org` only, with no GitHub Packages token in the environment, and `npm run build` renders the docs with the template.

The alternative was restoring the `.npmrc`, which would put the scope back on GitHub Packages and undo what that commit set out to do.
